### PR TITLE
hotstuff-rs-0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hotstuff_rs"
-version = "0.2.2"
+version = "0.3.0"
 description = "An implementation of the HotStuff consensus algorithm intended for production systems."
 homepage = "https://parallelchain.io"
 repository = "https://github.com/parallelchain-io/hotstuff_rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography::cryptocurrencies", "concurrency"]
 [dependencies]
 base64 = "0.21"
 borsh = "0.10"
-ed25519-dalek = "1"
+ed25519-dalek = "2.0.0"
 fern = "0.6"
 log = "0.4" 
 rand = "0.7"

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -301,7 +301,7 @@ fn propose_or_nudge<K: KVStore, N: Network>(
 
 // Returns (whether I voted, whether I am the next leader).
 fn on_receive_proposal<K: KVStore, N: Network>(
-    origin: &PublicKey,
+    origin: &VerifyingKey,
     proposal: &Proposal,
     me: &Keypair,
     chain_id: ChainID,
@@ -394,7 +394,7 @@ fn on_receive_proposal<K: KVStore, N: Network>(
 
 // Returns (whether I voted, whether I am the next leader).
 fn on_receive_nudge<K: KVStore, N: Network>(
-    origin: &PublicKey,
+    origin: &VerifyingKey,
     nudge: &Nudge,
     me: &Keypair,
     chain_id: ChainID,
@@ -482,7 +482,7 @@ fn on_receive_nudge<K: KVStore, N: Network>(
 
 // Returns (whether a new highest qc was collected, i am the next leader).
 fn on_receive_vote<K: KVStore>(
-    signer: &PublicKey,
+    signer: &VerifyingKey,
     vote: Vote,
     votes: &mut VoteCollector,
     block_tree: &mut BlockTree<K>,
@@ -555,7 +555,7 @@ fn on_receive_vote<K: KVStore>(
 
 // returns (whether I have collected new view messages from a quorum of validators && I am the next leader)
 fn on_receive_new_view<K: KVStore>(
-    origin: &PublicKey,
+    origin: &VerifyingKey,
     new_view: NewView,
     new_view_collector: &mut NewViewCollector,
     block_tree: &mut BlockTree<K>,
@@ -654,7 +654,7 @@ fn sync<K: KVStore, N: Network>(
 }
 
 fn sync_with<K: KVStore, N: Network>(
-    peer: &PublicKey,
+    peer: &VerifyingKey,
     block_tree: &mut BlockTree<K>,
     sync_stub: &mut SyncClientStub<N>,
     app: &mut impl App<K>,

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -51,6 +51,12 @@
 //! 3. If the view times out and reaches this step without reaching a step that transitions it into the next view, then
 //!    send a new view message containing my highest qc to the next leader.
 
+use std::cmp::max;
+use std::sync::mpsc::{Sender, Receiver, TryRecvError};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+use std::time::{Instant, SystemTime};
+
 use crate::app::App;
 use crate::app::ProduceBlockResponse;
 use crate::app::{ProduceBlockRequest, ValidateBlockRequest, ValidateBlockResponse};
@@ -60,11 +66,6 @@ use crate::networking::*;
 use crate::pacemaker::Pacemaker;
 use crate::state::*;
 use crate::types::*;
-use std::cmp::max;
-use std::sync::mpsc::{Sender, Receiver, TryRecvError};
-use std::thread::{self, JoinHandle};
-use std::time::Duration;
-use std::time::{Instant, SystemTime};
 
 /// Starts the algorithm thread, which runs an infinite loop until a shutdown signal is received.
 /// In each iteration of the loop the thread executes a view in the progress mode, and enters

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -78,11 +78,9 @@ pub(crate) fn start_algorithm<K: KVStore, N: Network + 'static>(
     event_publisher: Option<Sender<Event>>,
     sync_request_limit: u32,
     sync_response_timeout: Duration,
-    sync_trigger_timeout: Duration,
 ) -> JoinHandle<()> {
     thread::spawn(move || {
         let mut cur_view = 0;
-        let mut sync_trigger_timer = SyncTriggerTimer::new(sync_trigger_timeout);
 
         loop {
             match shutdown_signal.try_recv() {
@@ -111,10 +109,9 @@ pub(crate) fn start_algorithm<K: KVStore, N: Network + 'static>(
                 &mut pm_stub,
                 &mut app,
                 &event_publisher,
-                &mut sync_trigger_timer,
             );
             if let Err(ShouldSync) = view_result {
-                sync(&mut block_tree, &mut sync_stub, &mut app, chain_id, &event_publisher, sync_request_limit, sync_response_timeout, &mut sync_trigger_timer)
+                sync(&mut block_tree, &mut sync_stub, &mut app, chain_id, &event_publisher, sync_request_limit, sync_response_timeout)
             }
         }
     })
@@ -131,7 +128,6 @@ fn execute_view<K: KVStore, N: Network>(
     pm_stub: &mut ProgressMessageStub<N>,
     app: &mut impl App<K>,
     event_publisher: &Option<Sender<Event>>,
-    sync_trigger_timer: &mut SyncTriggerTimer,
 ) -> Result<(), ShouldSync> {
 
     let timeout = pacemaker.view_timeout(view, block_tree.highest_qc().view);
@@ -169,7 +165,6 @@ fn execute_view<K: KVStore, N: Network>(
                             &mut vote_collector,
                             &mut new_view_collector,
                             &event_publisher,
-                            sync_trigger_timer,
                         );
                         if voted && !i_am_next_leader {
                             return Ok(());
@@ -179,7 +174,7 @@ fn execute_view<K: KVStore, N: Network>(
                 ProgressMessage::Nudge(nudge) => {
                     if origin == cur_leader {
                         let (voted, i_am_next_leader) = on_receive_nudge(
-                            &origin, &nudge, me, chain_id, view, block_tree, pacemaker, pm_stub, event_publisher, sync_trigger_timer
+                            &origin, &nudge, me, chain_id, view, block_tree, pacemaker, pm_stub, event_publisher
                         );
                         if voted && !i_am_next_leader {
                             return Ok(());
@@ -219,6 +214,7 @@ fn execute_view<K: KVStore, N: Network>(
                     }
                 }
             },
+            Err(ProgressMessageReceiveError::ReceivedQCFromFuture) => return Err(ShouldSync),
             Err(ProgressMessageReceiveError::Timeout) => continue,
         };
     }
@@ -227,10 +223,6 @@ fn execute_view<K: KVStore, N: Network>(
     Event::ViewTimeout(ViewTimeoutEvent { timestamp: SystemTime::now(), view, timeout}).publish(event_publisher);
 
     on_view_timeout(chain_id, view, block_tree, pacemaker, pm_stub, event_publisher);
-
-    if sync_trigger_timer.timeout() {
-        return Err(ShouldSync)
-    }
 
     Ok(())
 }
@@ -314,7 +306,6 @@ fn on_receive_proposal<K: KVStore, N: Network>(
     vote_collector: &mut VoteCollector,
     new_view_collector: &mut NewViewCollector,
     event_publisher: &Option<Sender<Event>>,
-    sync_trigger_timer: &mut SyncTriggerTimer,
 ) -> (bool, bool) {
     Event::ReceiveProposal(ReceiveProposalEvent { timestamp: SystemTime::now(), origin: *origin, proposal: proposal.clone()}).publish(event_publisher);
 
@@ -342,12 +333,6 @@ fn on_receive_proposal<K: KVStore, N: Network>(
         validator_set_updates,
     } = app.validate_block(validate_block_request)
     {   
-        // Progress: on receiving acceptable proposal that extends the blockchain
-        if block_tree.children(&proposal.block.justify.block).is_none() || 
-            (block_tree.children(&proposal.block.justify.block).is_some() && block_tree.children(&proposal.block.justify.block).unwrap().is_empty()) {
-            sync_trigger_timer.update()
-        }
-
         let validator_set_updates_because_of_commit = block_tree.insert_block(
             &proposal.block,
             app_state_updates.as_ref(),
@@ -407,7 +392,6 @@ fn on_receive_nudge<K: KVStore, N: Network>(
     pacemaker: &mut impl Pacemaker,
     pm_stub: &mut ProgressMessageStub<N>,
     event_publisher: &Option<Sender<Event>>,
-    sync_trigger_timer: &mut SyncTriggerTimer,
 ) -> (bool, bool) {
     Event::ReceiveNudge(ReceiveNudgeEvent { timestamp: SystemTime::now(), origin: *origin, nudge: nudge.clone()}).publish(event_publisher);
 
@@ -430,9 +414,6 @@ fn on_receive_nudge<K: KVStore, N: Network>(
     if nudge.justify.view > block_tree.highest_qc().view {
         wb.set_highest_qc(&nudge.justify);
         update_highest_qc = Some(nudge.justify.clone());
-
-        // Progress: on receiving acceptable nudge with a **new** highest_qc
-        sync_trigger_timer.update();
     }
     let next_phase = match nudge.justify.phase {
         Phase::Prepare => {
@@ -649,11 +630,10 @@ fn sync<K: KVStore, N: Network>(
     event_publisher: &Option<Sender<Event>>,
     sync_request_limit: u32,
     sync_response_timeout: Duration,
-    sync_trigger_timer: &mut SyncTriggerTimer,
 ) {
     // Pick random validator.
     if let Some(peer) = block_tree.committed_validator_set().random() {
-        sync_with(peer, block_tree, sync_stub, app, chain_id, event_publisher, sync_request_limit, sync_response_timeout, sync_trigger_timer);
+        sync_with(peer, block_tree, sync_stub, app, chain_id, event_publisher, sync_request_limit, sync_response_timeout);
     }
 }
 
@@ -666,7 +646,6 @@ fn sync_with<K: KVStore, N: Network>(
     event_publisher: &Option<Sender<Event>>,
     sync_request_limit: u32,
     sync_response_timeout: Duration,
-    sync_trigger_timer: &mut SyncTriggerTimer,
 ) {
     Event::StartSync(StartSyncEvent { timestamp: SystemTime::now(), peer: peer.clone()}).publish(event_publisher);
     let mut blocks_synced = 0;
@@ -714,12 +693,6 @@ fn sync_with<K: KVStore, N: Network>(
                         validator_set_updates,
                     } = app.validate_block_for_sync(validate_block_request)
                     {   
-                        // Progress: on receiving acceptable block that extends the blockchain via sync
-                        if block_tree.children(&block.justify.block).is_none() || 
-                            (block_tree.children(&block.justify.block).is_some() && block_tree.children(&block.justify.block).unwrap().is_empty()) {
-                            sync_trigger_timer.update()
-                        }
-
                         let validator_set_updates_because_of_commit = block_tree.insert_block(
                             &block,
                             app_state_updates.as_ref(),

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -221,15 +221,16 @@ fn execute_view<K: KVStore, N: Network>(
             },
             Err(ProgressMessageReceiveError::Timeout) => continue,
         };
-        if sync_trigger_timer.timeout() {
-            return Err(ShouldSync)
-        }
     }
 
     // 3. If the view times out, send a New View message.
     Event::ViewTimeout(ViewTimeoutEvent { timestamp: SystemTime::now(), view, timeout}).publish(event_publisher);
 
     on_view_timeout(chain_id, view, block_tree, pacemaker, pm_stub, event_publisher);
+
+    if sync_trigger_timer.timeout() {
+        return Err(ShouldSync)
+    }
 
     Ok(())
 }

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -66,6 +66,9 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 use std::time::{Instant, SystemTime};
 
+/// Starts the algorithm thread, which runs an infinite loop until a shutdown signal is received.
+/// In each iteration of the loop the thread executes a view in the progress mode, and enters
+/// a sync mode if executing the view throws a [ShouldSync](ShouldSync) error.
 pub(crate) fn start_algorithm<K: KVStore, N: Network + 'static>(
     mut app: impl App<K> + 'static,
     me: Keypair,
@@ -117,8 +120,8 @@ pub(crate) fn start_algorithm<K: KVStore, N: Network + 'static>(
     })
 }
 
-/// Returns an Err(ShouldSync) if we encountered a quorum certificate for a future view in the execution, which suggests that a quorum of replicas are making
-/// progress at a higher view, so we should probably sync up to them.
+/// Returns an the [ShouldSync](ShouldSync) error if we encountered a [quorum certificate](crate::types::QuorumCertificate) for a future view in the execution, 
+/// which suggests that a quorum of replicas are making progress at a higher view, so we should probably sync up to them.
 fn execute_view<K: KVStore, N: Network>(
     me: &Keypair,
     chain_id: ChainID,
@@ -538,7 +541,7 @@ fn on_receive_vote<K: KVStore>(
     (highest_qc_updated, i_am_next_leader)
 }
 
-// returns (whether I have collected new view messages from a quorum of validators && I am the next leader)
+// Returns (whether I have collected new view messages from a quorum of validators && I am the next leader)
 fn on_receive_new_view<K: KVStore>(
     origin: &VerifyingKey,
     new_view: NewView,

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -272,7 +272,7 @@ fn propose_or_nudge<K: KVStore, N: Network>(
 
 // Returns (whether I voted, whether I am the next leader).
 fn on_receive_proposal<K: KVStore, N: Network>(
-    origin: &PublicKeyBytes,
+    origin: &PublicKey,
     proposal: &Proposal,
     me: &Keypair,
     cur_view: ViewNumber,
@@ -357,7 +357,7 @@ fn on_receive_proposal<K: KVStore, N: Network>(
 
 // Returns (whether I voted, whether I am the next leader).
 fn on_receive_nudge<K: KVStore, N: Network>(
-    origin: &PublicKeyBytes,
+    origin: &PublicKey,
     nudge: &Nudge,
     me: &Keypair,
     cur_view: ViewNumber,
@@ -421,7 +421,7 @@ fn on_receive_nudge<K: KVStore, N: Network>(
 
 // Returns (whether a new highest qc was collected, i am the next leader).
 fn on_receive_vote<K: KVStore>(
-    signer: &PublicKeyBytes,
+    signer: &PublicKey,
     vote: Vote,
     votes: &mut VoteCollector,
     block_tree: &mut BlockTree<K>,
@@ -473,7 +473,7 @@ fn on_receive_vote<K: KVStore>(
 
 // returns (whether I have collected new view messages from a quorum of validators && I am the next leader)
 fn on_receive_new_view<K: KVStore>(
-    origin: &PublicKeyBytes,
+    origin: &PublicKey,
     new_view: NewView,
     new_view_collector: &mut NewViewCollector,
     block_tree: &mut BlockTree<K>,
@@ -548,7 +548,7 @@ fn sync<K: KVStore, N: Network>(
 }
 
 fn sync_with<K: KVStore, N: Network>(
-    peer: &PublicKeyBytes,
+    peer: &PublicKey,
     block_tree: &mut BlockTree<K>,
     sync_stub: &mut SyncClientStub<N>,
     app: &mut impl App<K>,

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -342,7 +342,8 @@ fn on_receive_proposal<K: KVStore, N: Network>(
     } = app.validate_block(validate_block_request)
     {   
         // Progress: on receiving acceptable proposal that extends the blockchain
-        if parent_block.is_none() || block_tree.children(parent_block.unwrap()).is_none() {
+        if block_tree.children(&proposal.block.justify.block).is_none() || 
+            (block_tree.children(&proposal.block.justify.block).is_some() && block_tree.children(&proposal.block.justify.block).unwrap().is_empty()) {
             sync_trigger_timer.update()
         }
 
@@ -713,7 +714,8 @@ fn sync_with<K: KVStore, N: Network>(
                     } = app.validate_block_for_sync(validate_block_request)
                     {   
                         // Progress: on receiving acceptable block that extends the blockchain via sync
-                        if parent_block.is_none() || block_tree.children(parent_block.unwrap()).is_none() {
+                        if block_tree.children(&block.justify.block).is_none() || 
+                            (block_tree.children(&block.justify.block).is_some() && block_tree.children(&block.justify.block).unwrap().is_empty()) {
                             sync_trigger_timer.update()
                         }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -41,9 +41,9 @@ use crate::state::{AppBlockTreeView, KVStore};
 use crate::types::*;
 
 pub trait App<K: KVStore>: Send {
-    fn chain_id(&self) -> ChainID;
     fn produce_block(&mut self, request: ProduceBlockRequest<K>) -> ProduceBlockResponse;
     fn validate_block(&mut self, request: ValidateBlockRequest<K>) -> ValidateBlockResponse;
+    fn validate_block_for_sync(&mut self, request: ValidateBlockRequest<K>) -> ValidateBlockResponse;
 }
 
 pub struct ProduceBlockRequest<'a, K: KVStore> {

--- a/src/event_bus.rs
+++ b/src/event_bus.rs
@@ -15,11 +15,12 @@
 //! 2. If logging is enabled via replica's [config](crate::replica::Configuration) then also
 //!    the default logging handlers defined in [logging](crate::logging).
 
-use crate::events::*;
-use crate::logging::Logger;
 use std::sync::mpsc::{Receiver, TryRecvError};
 use std::thread;
 use std::thread::JoinHandle;
+
+use crate::events::*;
+use crate::logging::Logger;
 
 /// Pointer to a handler closure, parametrised by the argument (for our use case, event) type. 
 pub(crate) type HandlerPtr<T> = Box<dyn Fn(&T) + Send>;
@@ -43,7 +44,7 @@ impl<T: Logger> HandlerPair<T> {
     pub(crate) fn new(log: bool, user_defined_handler: Option<HandlerPtr<T>>) -> HandlerPair<T> {
         HandlerPair {
             user_defined_handler,
-            logging_handler: if log {Some(T::get_logger())} else {None}
+            logging_handler: if log { Some(T::get_logger()) } else { None }
         }
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,7 +1,7 @@
 //! Definitions of hotstuff-rs events for event handling and logging
 //! Note: an event for a given action indicates that the action has been completed
 
-use crate::types::{Block, QuorumCertificate, CryptoHash, ViewNumber, ValidatorSetUpdates, PublicKey};
+use crate::types::{Block, QuorumCertificate, CryptoHash, ViewNumber, ValidatorSetUpdates, VerifyingKey};
 use crate::messages::{Proposal, Nudge, Vote, NewView};
 use std::time::{SystemTime, Duration};
 use std::sync::mpsc::Sender;
@@ -96,31 +96,31 @@ pub struct NewViewEvent {
 
 pub struct ReceiveProposalEvent {
     pub timestamp: SystemTime,
-    pub origin: PublicKey,
+    pub origin: VerifyingKey,
     pub proposal: Proposal,
 }
 
 pub struct ReceiveNudgeEvent {
     pub timestamp: SystemTime,
-    pub origin: PublicKey,
+    pub origin: VerifyingKey,
     pub nudge: Nudge,
 }
 
 pub struct ReceiveVoteEvent {
     pub timestamp: SystemTime,
-    pub origin: PublicKey,
+    pub origin: VerifyingKey,
     pub vote: Vote,
 }
 
 pub struct ReceiveNewViewEvent {
     pub timestamp: SystemTime,
-    pub origin: PublicKey,
+    pub origin: VerifyingKey,
     pub new_view: NewView,
 }
 
 pub struct StartViewEvent {
     pub timestamp: SystemTime,
-    pub leader: PublicKey,
+    pub leader: VerifyingKey,
     pub view: ViewNumber,
 }
 
@@ -137,25 +137,25 @@ pub struct CollectQCEvent {
 
 pub struct StartSyncEvent {
     pub timestamp: SystemTime,
-    pub peer: PublicKey,
+    pub peer: VerifyingKey,
 }
 
 pub struct EndSyncEvent {
     pub timestamp: SystemTime,
-    pub peer: PublicKey,
+    pub peer: VerifyingKey,
     pub blocks_synced: u64,
 }
 
 pub struct ReceiveSyncRequestEvent {
     pub timestamp: SystemTime,
-    pub peer: PublicKey,
+    pub peer: VerifyingKey,
     pub start_height: u64,
     pub limit: u32,
 }
 
 pub struct SendSyncResponseEvent {
     pub timestamp: SystemTime,
-    pub peer: PublicKey,
+    pub peer: VerifyingKey,
     pub blocks: Vec<Block>,
     pub highest_qc: QuorumCertificate,
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -3,11 +3,18 @@
     Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 */
 
-//! Definitions of hotstuff-rs events for user-defined event handling and for logging.
-//! Hotstuff-rs events refer to the high-level descriptions of actions that are expected of
-//! a replica correctly executing the protocol.
+//! Definitions of HotStuff-rs events.
 //! 
-//! The [event](Event) enum is a wrapper enum for the all event types defined in this module.
+//! Events are emitted when significant steps of the protocol are executed by the replica,
+//! such as committing a block, starting a new view, or receiving a proposal.
+//! 
+//! Library users can register event handler closures, which are then called by the [event bus](crate::event_bus::start_event_bus)
+//! thread on receiving event notifications. Event handlers can be registered on starting a [replica](crate::replica).
+//! Default event handlers for logging can be enabled via the [replica's configuration](crate::replica::Configuration).
+//! 
+//! Note that events are always emitted **after** the corresponding action is completed.
+//! 
+//! The [event](Event) enum is a wrapper enum for the event types defined in this module.
 //! The event types are structs, storing all necessary information about a given event. 
 //! This information always includes a timestamp corresponding to the exact time when the event happened.
 //! 
@@ -24,7 +31,7 @@ use std::sync::mpsc::Sender;
 use crate::types::{Block, QuorumCertificate, CryptoHash, ViewNumber, ValidatorSetUpdates, VerifyingKey};
 use crate::messages::{Proposal, Nudge, Vote, NewView};
 
-/// Enumerates all events defined for hotstuff-rs.
+/// Enumerates all events defined for HotStuff-rs.
 pub enum Event {
     // Events that change persistent state.
     InsertBlock(InsertBlockEvent),
@@ -33,7 +40,7 @@ pub enum Event {
     UpdateHighestQC(UpdateHighestQCEvent),
     UpdateLockedView(UpdateLockedViewEvent),
     UpdateValidatorSet(UpdateValidatorSetEvent),
-    // Events that involve broadcasting/sending a Progress Message.
+    // Events that involve broadcasting or sending a Progress Message.
     Propose(ProposeEvent),
     Nudge(NudgeEvent),
     Vote(VoteEvent),
@@ -56,149 +63,148 @@ pub enum Event {
 
 impl Event {
     /// Publishes a given instance of the [Event](Event) enum on the event publisher channel (if the channel is defined).
-    pub(crate) fn publish(self, event_publisher: &Option<Sender<Event>>) {
+    pub fn publish(self, event_publisher: &Option<Sender<Event>>) {
         if let Some(event_publisher) = event_publisher {
             let _ = event_publisher.send(self);
         }
     }
 }
 
-/// This event corresponds to the replica inserting a new block into its [Block Tree](crate::state::BlockTree).
-/// The event includes all information about the block contained in the [Block](crate::types::Block) struct.
+/// A new block was inserted into the [Block Tree](crate::state::BlockTree) in a persistent manner.
+/// Includes all information about the insrted block contained in the [Block](crate::types::Block) struct.
 pub struct InsertBlockEvent {
     pub timestamp: SystemTime, 
     pub block: Block,
 }
 
-/// This event corresponds to the replica committing a block, identifiable by its [hash](crate::types::CryptoHash),
-/// and hence writing the changes associated with committing the block to its [Block Tree](crate::state::BlockTree).
+/// A block, identifiable by its [hash](crate::types::CryptoHash), was committed.
+/// This involves persistent changes to the [Block Tree](crate::state::BlockTree).
 pub struct CommitBlockEvent {
     pub timestamp: SystemTime,
     pub block: CryptoHash,
 }
 
-/// This event corresponds to the replica pruning a block, identifiable by its [hash](crate::types::CryptoHash),
-/// i.e., deleting the block's siblings from its [Block Tree](crate::state::BlockTree).
+/// A block, identifiable by its [hash](crate::types::CryptoHash), was pruned,
+/// i.e., the block's siblings were permanently deleted from the [Block Tree](crate::state::BlockTree).
 pub struct PruneBlockEvent {
     pub timestamp: SystemTime,
     pub block: CryptoHash,
 }
-
-/// This event corresponds to the replica updating the Highest Quroum Certificate stored in its [Block Tree](crate::state::BlockTree),
-/// and includes the new Highest [Quroum Certificate](crate::types::QuorumCertificate).
+/// The Highest Quroum Certificate, stored in the [Block Tree](crate::state::BlockTree), was updated.
+/// Includes the new Highest [Quroum Certificate](crate::types::QuorumCertificate).
 pub struct UpdateHighestQCEvent {
     pub timestamp: SystemTime,
     pub highest_qc: QuorumCertificate,
 }
 
-/// This event corresponds to the replica updating the Locked View stored in its [Block Tree](crate::state::BlockTree),
-/// and includes the [view number](crate::types::ViewNumber) of the new Locked View.
+/// The Locked View stored in the [Block Tree](crate::state::BlockTree) was updated.
+/// Includes the [view number](crate::types::ViewNumber) of the new Locked View.
 pub struct UpdateLockedViewEvent {
     pub timestamp: SystemTime,
     pub locked_view: ViewNumber,
 }
 
-/// This event corresponds to the replica updating the Committed Validator Set stored in its [Block Tree](crate::state::BlockTree).
-/// The event includes the [hash](crate::types::CryptoHash) of the block with which the updates are associated, and the information
+/// The committed validator set, stored in the [Block Tree](crate::state::BlockTree), was updated.
+/// Includes the [hash](crate::types::CryptoHash) of the block with which the updates are associated, and the information
 /// about the [validator set updates](crate::types::ValidatorSetUpdates), i.e., the insertions and deletions relative to the 
-/// previous Committed Validator Set.
+/// previous committed validator set.
 pub struct UpdateValidatorSetEvent {
     pub timestamp: SystemTime,
     pub cause_block: CryptoHash,
     pub validator_set_updates: ValidatorSetUpdates,
 }
 
-/// This event corresponds to the replica proposing a new block by broadcasting a [proposal](crate::messages::Proposal) to all
+/// The replica proposed a block by broadcasting it as a [proposal](crate::messages::Proposal) to all
 /// validators.
 pub struct ProposeEvent {
     pub timestamp: SystemTime,
     pub proposal: Proposal,
 }
 
-/// This event corresponds to the replica nudging for a block by broadcasting a [nudge](crate::messages::Nudge) to all
+/// The replica nudged for a block by broadcasting a [nudge](crate::messages::Nudge) for the block to all
 /// validators.
 pub struct NudgeEvent {
     pub timestamp: SystemTime,
     pub nudge: Nudge,
 }
 
-/// This event corresponds to the replica voting for a block by sending a [vote](crate::messages::Vote) to the leader.
+/// The replica voted for a block by sending a [vote](crate::messages::Vote) to the leader of the next view.
 pub struct VoteEvent {
     pub timestamp: SystemTime,
     pub vote: Vote,
 }
 
-/// This event corresponds to the replica sending a [new view](crate::messages::NewView) message to the leader upon moving to
-/// a new view.
+/// The replica sent a [new view](crate::messages::NewView) message for its current view 
+/// to the leader of the next view upon moving to a new view.
 pub struct NewViewEvent {
     pub timestamp: SystemTime,
     pub new_view: NewView,
 }
 
-/// This event corresponds to the replica receiving a [proposal](crate::messages::Proposal) from the leader identified
-/// by its [public key](ed25519_dalek::VerifyingKey).
+/// The replica received a [proposal](crate::messages::Proposal) for the replica's current view 
+/// from the leader of the view, identifiable by its [public key](ed25519_dalek::VerifyingKey).
 pub struct ReceiveProposalEvent {
     pub timestamp: SystemTime,
     pub origin: VerifyingKey,
     pub proposal: Proposal,
 }
 
-/// This event corresponds to the replica receiving a [nudge](crate::messages::Nudge) from the leader identified
-/// by its [public key](ed25519_dalek::VerifyingKey).
+/// The replica received a [nudge](crate::messages::Nudge) for the replica's current view 
+/// from the leader of the view, identifiable by its [public key](ed25519_dalek::VerifyingKey).
 pub struct ReceiveNudgeEvent {
     pub timestamp: SystemTime,
     pub origin: VerifyingKey,
     pub nudge: Nudge,
 }
 
-/// This event corresponds to the replica receiving a [vote](crate::messages::Vote) from another replica identified
-/// by its [public key](ed25519_dalek::VerifyingKey).
+/// The replica received a [vote](crate::messages::Vote) for the replica's current view 
+/// from another replica identifiable by its [public key](ed25519_dalek::VerifyingKey).
 pub struct ReceiveVoteEvent {
     pub timestamp: SystemTime,
     pub origin: VerifyingKey,
     pub vote: Vote,
 }
 
-/// This event corresponds to the replica receiving a [new view](crate::messages::NewView) message from another replica
-/// identified by its [public key](ed25519_dalek::VerifyingKey).
+/// The replica received a [new view](crate::messages::NewView) message for the current view
+/// from another replica identifiable by its [public key](ed25519_dalek::VerifyingKey).
 pub struct ReceiveNewViewEvent {
     pub timestamp: SystemTime,
     pub origin: VerifyingKey,
     pub new_view: NewView,
 }
 
-/// This event corresponds to the replica starting a new view with a given [view number](crate::types::ViewNumber) and
-/// a given leader identified by its [public key](ed25519_dalek::VerifyingKey).
+/// The replica started a new view with a given [view number](crate::types::ViewNumber) and
+/// a given leader identifiable by its [public key](ed25519_dalek::VerifyingKey).
 pub struct StartViewEvent {
     pub timestamp: SystemTime,
     pub leader: VerifyingKey,
     pub view: ViewNumber,
 }
 
-/// This event corresponds to the replica's view timeout for a view with a given [view number](crate::types::ViewNumber)
-/// after spending a given [amount of time](core::time::Duration) in the view.
+/// The replica's view, with a given [view number](crate::types::ViewNumber), timed out
+/// after a given [amount of time](core::time::Duration).
 pub struct ViewTimeoutEvent {
     pub timestamp: SystemTime,
     pub view: ViewNumber,
     pub timeout: Duration,
 }
 
-/// This event corresponds to the replica collecting a new [Quorum Certificate](crate::types::QuorumCertificate)
-/// from the votes it received from the validators.
+/// The replica collected a new [Quorum Certificate](crate::types::QuorumCertificate)
+/// from the votes it received from the validators in the current view.
 pub struct CollectQCEvent {
     pub timestamp: SystemTime,
     pub quorum_certificate: QuorumCertificate,
 }
 
-/// This event corresponds to the replica entering the sync mode and trying to sync with a given
-/// peer identified by its [public key](ed25519_dalek::VerifyingKey).
+/// The replica entered sync mode and tried to sync with a given
+/// peer identifiable by its [public key](ed25519_dalek::VerifyingKey).
 pub struct StartSyncEvent {
     pub timestamp: SystemTime,
     pub peer: VerifyingKey,
 }
 
-/// This event corresponds to the replica exiting the sync mode, during which it tried to sync with 
-/// a given peer identified by its [public key](ed25519_dalek::VerifyingKey), and inserted a given
+/// The replica exited sync mode, during which it tried to sync with 
+/// a given peer identifiable by its [public key](ed25519_dalek::VerifyingKey), and inserted a given
 /// number of blocks received from the peer into its [Block Tree](crate::state::BlockTree).
 pub struct EndSyncEvent {
     pub timestamp: SystemTime,
@@ -206,8 +212,8 @@ pub struct EndSyncEvent {
     pub blocks_synced: u64,
 }
 
-/// This event corresponds to the replica's [sync_server](crate::sync_server) receiving a [sync request](crate::messages::SyncRequest)
-/// from a peer identified by its [public key](ed25519_dalek::VerifyingKey). The event includes information
+/// The replica's [sync_server](crate::sync_server) received a [sync request](crate::messages::SyncRequest)
+/// from a peer identifiable by its [public key](ed25519_dalek::VerifyingKey). Includes information
 /// about the requested start height from which the peer wants to sync, and the limit on the number of blocks
 /// that can be sent in a [sync response](crate::messages::SyncResponse).
 pub struct ReceiveSyncRequestEvent {
@@ -217,8 +223,8 @@ pub struct ReceiveSyncRequestEvent {
     pub limit: u32,
 }
 
-/// This event corresponds to the replica's [sync_server](crate::sync_server) sending a [sync response](crate::messages::SyncResponse)
-/// to a peer identified by its [public key](ed25519_dalek::VerifyingKey). The event includes information
+/// The replica's [sync_server](crate::sync_server) sent a [sync response](crate::messages::SyncResponse)
+/// to a peer identifiable by its [public key](ed25519_dalek::VerifyingKey). Includes information
 /// about the vector of [blocks](crate::types::Block) and the Highest [Quroum Certificate](crate::types::QuorumCertificate) sent to the peer.
 pub struct SendSyncResponseEvent {
     pub timestamp: SystemTime,

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,11 +1,29 @@
-//! Definitions of hotstuff-rs events for event handling and logging
-//! Note: an event for a given action indicates that the action has been completed
+/*
+    Copyright © 2023, ParallelChain Lab
+    Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+//! Definitions of hotstuff-rs events for user-defined event handling and for logging.
+//! Hotstuff-rs events refer to the high-level descriptions of actions that are expected of
+//! a replica correctly executing the protocol.
+//! 
+//! The [event](Event) enum is a wrapper enum for the all event types defined in this module.
+//! The event types are structs, storing all necessary information about a given event. 
+//! This information always includes a timestamp corresponding to the exact time when the event happened.
+//! 
+//! Event notifications are sent from the [algorithm](crate::algorithm) and [sync_server](crate::sync_server)
+//! threads and received and processed by the [event_bus](crate::event_bus) thread, according to the
+//! predefined handlers.
+//! 
+//! Additionally, a [convenience method](Event::publish) is defined for publishing an event by sending it
+//! via an appropriate channel.
 
 use crate::types::{Block, QuorumCertificate, CryptoHash, ViewNumber, ValidatorSetUpdates, VerifyingKey};
 use crate::messages::{Proposal, Nudge, Vote, NewView};
 use std::time::{SystemTime, Duration};
 use std::sync::mpsc::Sender;
 
+/// Enumerates all events defined for hotstuff-rs.
 pub enum Event {
     // Events that change persistent state.
     InsertBlock(InsertBlockEvent),
@@ -36,6 +54,7 @@ pub enum Event {
 }
 
 impl Event {
+    /// Publishes a given instance of the [Event](Event) enum on the event publisher channel (if the channel is defined).
     pub(crate) fn publish(self, event_publisher: &Option<Sender<Event>>) {
         if let Some(event_publisher) = event_publisher {
             let _ = event_publisher.send(self);
@@ -43,109 +62,153 @@ impl Event {
     }
 }
 
+/// This event corresponds to the replica inserting a new block into its [Block Tree](crate::state::BlockTree).
+/// The event includes all information about the block contained in the [Block](crate::types::Block) struct.
 pub struct InsertBlockEvent {
     pub timestamp: SystemTime, 
     pub block: Block,
 }
 
+/// This event corresponds to the replica committing a block, identifiable by its [hash](crate::types::CryptoHash),
+/// and hence writing the changes associated with committing the block to its [Block Tree](crate::state::BlockTree).
 pub struct CommitBlockEvent {
     pub timestamp: SystemTime,
     pub block: CryptoHash,
 }
 
+/// This event corresponds to the replica pruning a block, identifiable by its [hash](crate::types::CryptoHash),
+/// i.e., deleting the block's siblings from its [Block Tree](crate::state::BlockTree).
 pub struct PruneBlockEvent {
     pub timestamp: SystemTime,
     pub block: CryptoHash,
 }
 
+/// This event corresponds to the replica updating the Highest Quroum Certificate stored in its [Block Tree](crate::state::BlockTree),
+/// and includes the new Highest [Quroum Certificate](crate::types::QuorumCertificate).
 pub struct UpdateHighestQCEvent {
     pub timestamp: SystemTime,
     pub highest_qc: QuorumCertificate,
 }
 
+/// This event corresponds to the replica updating the Locked View stored in its [Block Tree](crate::state::BlockTree),
+/// and includes the [view number](crate::types::ViewNumber) of the new Locked View.
 pub struct UpdateLockedViewEvent {
     pub timestamp: SystemTime,
     pub locked_view: ViewNumber,
 }
 
+/// This event corresponds to the replica updating the Committed Validator Set stored in its [Block Tree](crate::state::BlockTree).
+/// The event includes the [hash](crate::types::CryptoHash) of the block with which the updates are associated, and the information
+/// about the [validator set updates](crate::types::ValidatorSetUpdates), i.e., the insertions and deletions relative to the 
+/// previous Committed Validator Set.
 pub struct UpdateValidatorSetEvent {
     pub timestamp: SystemTime,
     pub cause_block: CryptoHash,
     pub validator_set_updates: ValidatorSetUpdates,
 }
 
+/// This event corresponds to the replica proposing a new block by broadcasting a [proposal](crate::messages::Proposal) to all
+/// validators.
 pub struct ProposeEvent {
     pub timestamp: SystemTime,
     pub proposal: Proposal,
 }
 
+/// This event corresponds to the replica nudging for a block by broadcasting a [nudge](crate::messages::Nudge) to all
+/// validators.
 pub struct NudgeEvent {
     pub timestamp: SystemTime,
     pub nudge: Nudge,
 }
 
+/// This event corresponds to the replica voting for a block by sending a [vote](crate::messages::Vote) to the leader.
 pub struct VoteEvent {
     pub timestamp: SystemTime,
     pub vote: Vote,
 }
 
+/// This event corresponds to the replica sending a [new view](crate::messages::NewView) message to the leader upon moving to
+/// a new view.
 pub struct NewViewEvent {
     pub timestamp: SystemTime,
     pub new_view: NewView,
 }
 
+/// This event corresponds to the replica receiving a [proposal](crate::messages::Proposal) from the leader identified
+/// by its [public key](ed25519_dalek::VerifyingKey).
 pub struct ReceiveProposalEvent {
     pub timestamp: SystemTime,
     pub origin: VerifyingKey,
     pub proposal: Proposal,
 }
 
+/// This event corresponds to the replica receiving a [nudge](crate::messages::Nudge) from the leader identified
+/// by its [public key](ed25519_dalek::VerifyingKey).
 pub struct ReceiveNudgeEvent {
     pub timestamp: SystemTime,
     pub origin: VerifyingKey,
     pub nudge: Nudge,
 }
 
+/// This event corresponds to the replica receiving a [vote](crate::messages::Vote) from another replica identified
+/// by its [public key](ed25519_dalek::VerifyingKey).
 pub struct ReceiveVoteEvent {
     pub timestamp: SystemTime,
     pub origin: VerifyingKey,
     pub vote: Vote,
 }
 
+/// This event corresponds to the replica receiving a [new view](crate::messages::NewView) message from another replica
+/// identified by its [public key](ed25519_dalek::VerifyingKey).
 pub struct ReceiveNewViewEvent {
     pub timestamp: SystemTime,
     pub origin: VerifyingKey,
     pub new_view: NewView,
 }
 
+/// This event corresponds to the replica starting a new view with a given [view number](crate::types::ViewNumber) and
+/// a given leader identified by its [public key](ed25519_dalek::VerifyingKey).
 pub struct StartViewEvent {
     pub timestamp: SystemTime,
     pub leader: VerifyingKey,
     pub view: ViewNumber,
 }
 
+/// This event corresponds to the replica's view timeout for a view with a given [view number](crate::types::ViewNumber)
+/// after spending a given [amount of time](core::time::Duration) in the view.
 pub struct ViewTimeoutEvent {
     pub timestamp: SystemTime,
     pub view: ViewNumber,
     pub timeout: Duration,
 }
 
+/// This event corresponds to the replica collecting a new [Quorum Certificate](crate::types::QuorumCertificate)
+/// from the votes it received from the validators.
 pub struct CollectQCEvent {
     pub timestamp: SystemTime,
     pub quorum_certificate: QuorumCertificate,
 }
 
+/// This event corresponds to the replica entering the sync mode and trying to sync with a given
+/// peer identified by its [public key](ed25519_dalek::VerifyingKey).
 pub struct StartSyncEvent {
     pub timestamp: SystemTime,
     pub peer: VerifyingKey,
 }
 
+/// This event corresponds to the replica exiting the sync mode, during which it tried to sync with 
+/// a given peer identified by its [public key](ed25519_dalek::VerifyingKey), and inserted a given
+/// number of blocks received from the peer into its [Block Tree](crate::state::BlockTree).
 pub struct EndSyncEvent {
     pub timestamp: SystemTime,
     pub peer: VerifyingKey,
     pub blocks_synced: u64,
 }
 
+/// This event corresponds to a replica's [sync_server](crate::sync_server) receiving a [sync request](crate::messages::SyncRequest)
+/// from a peer identified by its [public key](ed25519_dalek::VerifyingKey). The event includes information
+/// about the requested start height from which the peer wants to sync, and the limit on the number of blocks
+/// that can be sent in a [sync response](crate::messages::SyncResponse).
 pub struct ReceiveSyncRequestEvent {
     pub timestamp: SystemTime,
     pub peer: VerifyingKey,
@@ -153,6 +216,9 @@ pub struct ReceiveSyncRequestEvent {
     pub limit: u32,
 }
 
+/// This event corresponds to a replica's [sync_server](crate::sync_server) sending a [sync response](crate::messages::SyncResponse)
+/// to a peer identified by its [public key](ed25519_dalek::VerifyingKey). The event includes information
+/// about the vector of [blocks](crate::types::Block) and the Highest [Quroum Certificate](crate::types::QuorumCertificate) sent to the peer.
 pub struct SendSyncResponseEvent {
     pub timestamp: SystemTime,
     pub peer: VerifyingKey,

--- a/src/events.rs
+++ b/src/events.rs
@@ -36,9 +36,9 @@ pub enum Event {
 }
 
 impl Event {
-    pub(crate) fn publish(event_publisher: &Option<Sender<Event>>, event: Event) {
+    pub(crate) fn publish(self, event_publisher: &Option<Sender<Event>>) {
         if let Some(event_publisher) = event_publisher {
-            let _ = event_publisher.send(event);
+            let _ = event_publisher.send(self);
         }
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -18,10 +18,11 @@
 //! Additionally, a [convenience method](Event::publish) is defined for publishing an event by sending it
 //! via an appropriate channel.
 
-use crate::types::{Block, QuorumCertificate, CryptoHash, ViewNumber, ValidatorSetUpdates, VerifyingKey};
-use crate::messages::{Proposal, Nudge, Vote, NewView};
 use std::time::{SystemTime, Duration};
 use std::sync::mpsc::Sender;
+
+use crate::types::{Block, QuorumCertificate, CryptoHash, ViewNumber, ValidatorSetUpdates, VerifyingKey};
+use crate::messages::{Proposal, Nudge, Vote, NewView};
 
 /// Enumerates all events defined for hotstuff-rs.
 pub enum Event {
@@ -205,7 +206,7 @@ pub struct EndSyncEvent {
     pub blocks_synced: u64,
 }
 
-/// This event corresponds to a replica's [sync_server](crate::sync_server) receiving a [sync request](crate::messages::SyncRequest)
+/// This event corresponds to the replica's [sync_server](crate::sync_server) receiving a [sync request](crate::messages::SyncRequest)
 /// from a peer identified by its [public key](ed25519_dalek::VerifyingKey). The event includes information
 /// about the requested start height from which the peer wants to sync, and the limit on the number of blocks
 /// that can be sent in a [sync response](crate::messages::SyncResponse).
@@ -216,7 +217,7 @@ pub struct ReceiveSyncRequestEvent {
     pub limit: u32,
 }
 
-/// This event corresponds to a replica's [sync_server](crate::sync_server) sending a [sync response](crate::messages::SyncResponse)
+/// This event corresponds to the replica's [sync_server](crate::sync_server) sending a [sync response](crate::messages::SyncResponse)
 /// to a peer identified by its [public key](ed25519_dalek::VerifyingKey). The event includes information
 /// about the vector of [blocks](crate::types::Block) and the Highest [Quroum Certificate](crate::types::QuorumCertificate) sent to the peer.
 pub struct SendSyncResponseEvent {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@
 //!    applications.
 //! 6. **Batteries included**: comes with a block-sync protocol and (coming soon) default implementations for networking,
 //!    state, and pacemaker: you write the app, we handle the replication.
+//! 7. **Support for event-driven programming**: a simple API for registering user-defined event handlers, triggered
+//!     in response to HotStuff-rs protocol event notifications.
 //!
 //! ## Terminology
 //!  
@@ -40,7 +42,9 @@
 //! To replicate your application using HotStuff-rs, you need to represent it as a type and then
 //! have the type implement the [app] trait.
 //!
-//! Then, [initialize](replica::Replica::initialize) a [replica], and then [start](replica::Replica::start) it.
+//! Then, [initialize](replica::Replica::initialize) a [replica]'s storage, 
+//! [build](replica::ReplicaSpec::builder) the replica's [specification](crate::replica::ReplicaSpec),
+//! and then [start](replica::ReplicaSpec::start) it. An example can be found [here](crate::replica).
 
 pub mod app;
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -3,13 +3,13 @@
     Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 */
 
-//! Functions for logging out library events of varying levels of importance.
+//! Functions for logging out hotstuff-rs events defined in [events](crate::events).
 //!
+//! The logs defined in this module are enabled if the user enabled them via replica's [config](crate::replica::Configuration).
+//! 
 //! HotStuff-rs logs using the [log](https://docs.rs/log/latest/log/) crate. To get these messages
 //! printed onto a terminal or to a file, set up a [logging
 //! implementation](https://docs.rs/log/latest/log/#available-logging-implementations).
-//!
-//! Log messages with past tense event names (e.g., "Proposed") indicate an activity that has completed
 
 use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine as _};
 use log;
@@ -42,7 +42,9 @@ pub const END_SYNC: &str = "FinishedSyncing";
 pub const RECEIVE_SYNC_REQUEST: &str = "ReceivedSyncRequest";
 pub const SEND_SYNC_RESPONSE: &str = "SentSyncResponse";
 
+/// Abstraction for event types that have default logging handlers defined.
 pub(crate) trait Logger {
+    /// Returns a pointer to the default logging handler for a given event type.
     fn get_logger() -> Box<dyn Fn(&Self) + Send>;
 }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -5,7 +5,7 @@
 
 //! Functions for logging out hotstuff-rs events defined in [events](crate::events).
 //!
-//! The logs defined in this module are enabled if the user enabled them via replica's [config](crate::replica::Configuration).
+//! The logs defined in this module are printed if the user enabled them via replica's [config](crate::replica::Configuration).
 //! 
 //! HotStuff-rs logs using the [log](https://docs.rs/log/latest/log/) crate. To get these messages
 //! printed onto a terminal or to a file, set up a [logging

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -176,7 +176,7 @@ impl Logger for NewViewEvent {
         let logger = |new_view_event: &NewViewEvent| {
             log::info!(
                 "{}, {:?}, {}, {}, {:?}",
-                VIEW_TIME_OUT,
+                NEWVIEW,
                 new_view_event.timestamp,
                 succinct(&new_view_event.new_view.highest_qc.block),
                 new_view_event.new_view.view,

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -77,8 +77,8 @@ pub mod info {
         );
     }
 
-    pub(crate) fn start_syncing(sync_peer: &PublicKeyBytes) {
-        log::info!("{}, {}", START_SYNCING, succinct(sync_peer))
+    pub(crate) fn start_syncing(sync_peer: &PublicKey) {
+        log::info!("{}, {}", START_SYNCING, succinct(&sync_peer.to_bytes()))
     }
 }
 
@@ -102,45 +102,45 @@ pub mod debug {
     }
 
     pub(crate) fn received_proposal(
-        origin: &PublicKeyBytes,
+        origin: &PublicKey,
         block: &CryptoHash,
         height: BlockHeight,
     ) {
         log::debug!(
             "{}, {}, {}, {}",
             RECEIVED_PROPOSAL,
-            succinct(origin),
+            succinct(&origin.to_bytes()),
             succinct(block),
             height
         );
     }
 
     pub(crate) fn received_nudge(
-        origin: &PublicKeyBytes,
+        origin: &PublicKey,
         justify_block: &CryptoHash,
         justify_phase: Phase,
     ) {
         log::debug!(
             "{}, {}, {}, {:?}",
             RECEIVED_NUDGE,
-            succinct(origin),
+            succinct(&origin.to_bytes()),
             succinct(justify_block),
             justify_phase
         );
     }
 
-    pub(crate) fn received_vote(origin: &PublicKeyBytes, block: &CryptoHash, phase: Phase) {
+    pub(crate) fn received_vote(origin: &PublicKey, block: &CryptoHash, phase: Phase) {
         log::debug!(
             "{}, {}, {}, {:?}",
             RECEIVED_VOTE,
-            succinct(origin),
+            succinct(&origin.to_bytes()),
             succinct(block),
             phase
         );
     }
 
     pub(crate) fn received_new_view(
-        origin: &PublicKeyBytes,
+        origin: &PublicKey,
         view: ViewNumber,
         block: &CryptoHash,
         phase: Phase,
@@ -148,7 +148,7 @@ pub mod debug {
         log::debug!(
             "{}, {}, {}, {}, {:?}",
             RECEIVED_NEW_VIEW,
-            succinct(origin),
+            succinct(&origin.to_bytes()),
             view,
             succinct(block),
             phase
@@ -171,8 +171,8 @@ pub mod debug {
         log::debug!("{}, {}, {:?}", REPLACING_HIGHEST_QC, succinct(block), phase);
     }
 
-    pub(crate) fn received_sync_request(origin: &CryptoHash) {
-        log::debug!("{}, {}", RECEIVED_SYNC_REQUEST, succinct(origin));
+    pub(crate) fn received_sync_request(origin: &PublicKey) {
+        log::debug!("{}, {}", RECEIVED_SYNC_REQUEST, succinct(&origin.to_bytes()));
     }
 }
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -3,13 +3,23 @@
     Licensed under the Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
 */
 
-//! Functions for logging out hotstuff-rs events defined in [events](crate::events).
+//! Functions for logging out HotStuff-rs events defined in [events](crate::events).
 //!
 //! The logs defined in this module are printed if the user enabled them via replica's [config](crate::replica::Configuration).
 //! 
 //! HotStuff-rs logs using the [log](https://docs.rs/log/latest/log/) crate. To get these messages
 //! printed onto a terminal or to a file, set up a [logging
 //! implementation](https://docs.rs/log/latest/log/#available-logging-implementations).
+//! 
+//! The log messages follow a CSV-like formatting style, with the following information separated by commas:
+//! 1. Event name,
+//! 2. Timestamp,
+//! 3. Public key (if any),
+//! 4. Block hash (if any),
+//! 5. Block height (if any),
+//! 6. View (if any),
+//! 7. Phase (if any),
+//! 8. Other information (if any).
 
 use base64::{engine::general_purpose::STANDARD_NO_PAD, Engine as _};
 use log;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -16,10 +16,6 @@ use log;
 
 pub(crate) use crate::events::*;
 
-pub(crate) trait Logger {
-    fn get_logger() -> Box<dyn Fn(&Self) + Send>;
-}
-
 pub const INSERT_BLOCK: &str = "InsertedBlock";
 pub const COMMIT_BLOCK: &str = "CommittedBlock";
 pub const PRUNE_BLOCK: &str = "PrunedBlock";
@@ -45,6 +41,10 @@ pub const START_SYNC: &str = "StartedSyncing";
 pub const END_SYNC: &str = "FinishedSyncing";
 pub const RECEIVE_SYNC_REQUEST: &str = "ReceivedSyncRequest";
 pub const SEND_SYNC_RESPONSE: &str = "SentSyncResponse";
+
+pub(crate) trait Logger {
+    fn get_logger() -> Box<dyn Fn(&Self) + Send>;
+}
 
 impl Logger for InsertBlockEvent {
     fn get_logger() -> Box<dyn Fn(&Self) + Send> {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -151,8 +151,8 @@ pub struct SyncResponse {
 pub(crate) struct Keypair(pub(crate) SigningKey);
 
 impl Keypair {
-    pub(crate) fn new(private_key: SigningKey) -> Keypair {
-        Keypair(private_key)
+    pub(crate) fn new(signing_key: SigningKey) -> Keypair {
+        Keypair(signing_key)
     }
 
     pub(crate) fn vote(

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -8,6 +8,7 @@
 //! This includes messages [used in the progress protocol](ProgressMessage), and those [used in the sync protocol](SyncMessage).
 
 use std::mem;
+
 use borsh::{BorshDeserialize, BorshSerialize};
 use ed25519_dalek::{Signature, Signer, Verifier};
 
@@ -65,7 +66,7 @@ impl ProgressMessage {
         })
     }
 
-    /// Returns the chain ID associated with a given [ProgressMessage](ProgressMessage).
+    /// Returns the chain ID associated with a given [ProgressMessage].
     pub fn chain_id(&self) -> ChainID {
         match self {
             ProgressMessage::Proposal(Proposal { chain_id, .. }) => *chain_id,
@@ -75,7 +76,7 @@ impl ProgressMessage {
         }
     }
 
-    /// Returns the view number associated with a given [ProgressMessage](ProgressMessage).
+    /// Returns the view number associated with a given [ProgressMessage].
     pub fn view(&self) -> ViewNumber {
         match self {
             ProgressMessage::Proposal(Proposal { view, .. }) => *view,
@@ -85,7 +86,7 @@ impl ProgressMessage {
         }
     }
 
-    /// Returns the number of bytes required to store a given instance of the [ProgressMessage](ProgressMessage).
+    /// Returns the number of bytes required to store a given instance of the [ProgressMessage] enum.
     pub fn size(&self) -> u64 {
         match self {
             ProgressMessage::Proposal(_) => mem::size_of::<Proposal>() as u64,

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -65,6 +65,7 @@ impl ProgressMessage {
         })
     }
 
+    /// Returns the chain ID associated with a given [ProgressMessage](ProgressMessage).
     pub fn chain_id(&self) -> ChainID {
         match self {
             ProgressMessage::Proposal(Proposal { chain_id, .. }) => *chain_id,
@@ -74,6 +75,7 @@ impl ProgressMessage {
         }
     }
 
+    /// Returns the view number associated with a given [ProgressMessage](ProgressMessage).
     pub fn view(&self) -> ViewNumber {
         match self {
             ProgressMessage::Proposal(Proposal { view, .. }) => *view,
@@ -83,6 +85,7 @@ impl ProgressMessage {
         }
     }
 
+    /// Returns the number of bytes required to store a given instance of the [ProgressMessage](ProgressMessage).
     pub fn size(&self) -> u64 {
         match self {
             ProgressMessage::Proposal(_) => mem::size_of::<Proposal>() as u64,
@@ -156,7 +159,7 @@ pub struct SyncResponse {
     pub highest_qc: QuorumCertificate,
 }
 
-/// A wrapper around SigningKey which implements [a convenience method](ProgressMessage::vote) for creating properly
+/// A wrapper around [SigningKey](ed25519_dalek::SigningKey) which implements a [convenience method](Keypair::vote) for creating properly
 /// signed [votes](Vote).
 pub(crate) struct Keypair(pub(crate) SigningKey);
 
@@ -164,7 +167,8 @@ impl Keypair {
     pub(crate) fn new(signing_key: SigningKey) -> Keypair {
         Keypair(signing_key)
     }
-
+    
+    /// Convenience method for creating properly signed [votes](Vote).
     pub(crate) fn vote(
         &self,
         chain_id: ChainID,

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -7,6 +7,7 @@
 //!
 //! This includes messages [used in the progress protocol](ProgressMessage), and those [used in the sync protocol](SyncMessage).
 
+use std::mem;
 use borsh::{BorshDeserialize, BorshSerialize};
 use ed25519_dalek::{Signature, Signer, Verifier};
 
@@ -79,6 +80,15 @@ impl ProgressMessage {
             ProgressMessage::Nudge(Nudge { view, .. }) => *view,
             ProgressMessage::Vote(Vote { view, .. }) => *view,
             ProgressMessage::NewView(NewView { view, .. }) => *view,
+        }
+    }
+
+    pub fn size(&self) -> u64 {
+        match self {
+            ProgressMessage::Proposal(_) => mem::size_of::<Proposal>() as u64,
+            ProgressMessage::Nudge(_) => mem::size_of::<Nudge>() as u64,
+            ProgressMessage:: Vote(_) => mem::size_of::<Vote>() as u64,
+            ProgressMessage::NewView(_) => mem::size_of::<NewView>() as u64,
         }
     }
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -119,7 +119,7 @@ pub struct Vote {
 impl Vote {
     /// # Panics
     /// pk must be a valid public key.
-    pub fn is_correct(&self, pk: &PublicKey) -> bool {
+    pub fn is_correct(&self, pk: &VerifyingKey) -> bool {
         let signature = Signature::from_bytes(&self.signature);
         pk.verify(
         &(self.chain_id, self.view, self.block, self.phase)
@@ -185,7 +185,7 @@ impl Keypair {
         })
     }
 
-    pub(crate) fn public(&self) -> PublicKey {
+    pub(crate) fn public(&self) -> VerifyingKey {
         self.0.verifying_key()
     }
 }

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -154,7 +154,7 @@ impl<N: Network> ProgressMessageStub<N> {
                     // (unless the buffer is overloaded in which case we need to make space or ignore the message).
                     else if msg.view() > cur_view {
 
-                        let bytes_requested = mem::size_of::<PublicKey>() as u64 + Self::size_of_msg(&msg);
+                        let bytes_requested = mem::size_of::<PublicKey>() as u64 + msg.size();
                         let new_buffer_size = self.msg_buffer_size.checked_add(bytes_requested);
                         let overloaded_buffer = new_buffer_size.is_none() || new_buffer_size.unwrap() > self.msg_buffer_capacity;
                         let cache_message_if_overloaded_buffer = self.msg_buffer.keys().max().is_some() && msg.view() < self.msg_buffer.keys().max().copied().unwrap();
@@ -223,7 +223,7 @@ impl<N: Network> ProgressMessageStub<N> {
                     .take_while(|(_, msg)| 
                         {
                             if bytes_removed < bytes_to_remove {
-                                bytes_removed += Self::size_of_msg(msg) + public_key_size;
+                                bytes_removed += msg.size() + public_key_size;
                                 true
                             } else {
                                 false
@@ -242,15 +242,6 @@ impl<N: Network> ProgressMessageStub<N> {
 
         views_removed.iter().for_each(|view| {let _ = self.msg_buffer.remove(view);});
 
-    }
-
-    fn size_of_msg(msg: &ProgressMessage) -> u64 {
-        match msg {
-            ProgressMessage::Proposal(_) => mem::size_of::<Proposal>() as u64,
-            ProgressMessage::Nudge(_) => mem::size_of::<Nudge>() as u64,
-            ProgressMessage:: Vote(_) => mem::size_of::<Vote>() as u64,
-            ProgressMessage::NewView(_) => mem::size_of::<NewView>() as u64,
-        }
     }
 
 }

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -146,21 +146,6 @@ impl<N: Network> ProgressMessageStub<N> {
                         continue;
                     }
 
-                    // Inform the caller that we've received a QC from the future.
-                    let received_qc_from_future = match &msg {
-                        ProgressMessage::Proposal(Proposal { block, .. }) => {
-                            block.justify.view > cur_view
-                        }
-                        ProgressMessage::Nudge(Nudge { justify, .. }) => justify.view > cur_view,
-                        ProgressMessage::NewView(NewView { highest_qc, .. }) => {
-                            highest_qc.view > cur_view
-                        }
-                        _ => false,
-                    };
-                    if received_qc_from_future {
-                        return Err(ProgressMessageReceiveError::ReceivedQCFromFuture);
-                    }
-
                     // Return the message if its for the current view.
                     if msg.view() == cur_view {
                         return Ok((sender, msg));
@@ -271,7 +256,6 @@ impl<N: Network> ProgressMessageStub<N> {
 
 pub(crate) enum ProgressMessageReceiveError {
     Timeout,
-    ReceivedQCFromFuture,
 }
 
 pub(crate) struct SyncClientStub<N: Network> {

--- a/src/pacemaker.rs
+++ b/src/pacemaker.rs
@@ -36,18 +36,12 @@ pub trait Pacemaker: Send {
 
     fn view_leader(&mut self, cur_view: ViewNumber, validator_set: &ValidatorSet)
         -> PublicKey;
-
-    fn sync_request_limit(&self) -> u32;
-
-    fn sync_response_timeout(&self) -> Duration;
 }
 
 /// A pacemaker which selects leaders in a round-robin fashion, and prescribes exponentially increasing view timeouts to
 /// eventually bring replicas into the same view.
 pub struct DefaultPacemaker {
     minimum_view_timeout: Duration,
-    sync_request_limit: u32,
-    sync_response_timeout: Duration,
 }
 
 impl DefaultPacemaker {
@@ -55,15 +49,9 @@ impl DefaultPacemaker {
     ///
     /// `minimum_view_timeout` and `sync_response_timeout` must not be larger than [u32::MAX] seconds for reasons
     /// explained in [Pacemaker].
-    pub fn new(
-        minimum_view_timeout: Duration,
-        sync_request_limit: u32,
-        sync_response_timeout: Duration,
-    ) -> DefaultPacemaker {
+    pub fn new(minimum_view_timeout: Duration) -> DefaultPacemaker {
         Self {
             minimum_view_timeout,
-            sync_request_limit,
-            sync_response_timeout,
         }
     }
 }
@@ -92,13 +80,5 @@ impl Pacemaker for DefaultPacemaker {
                 u32::checked_pow(2, exp).map_or(u32::MAX, identity) as u64,
                 0,
             )
-    }
-
-    fn sync_request_limit(&self) -> u32 {
-        self.sync_request_limit
-    }
-
-    fn sync_response_timeout(&self) -> Duration {
-        self.sync_response_timeout
     }
 }

--- a/src/pacemaker.rs
+++ b/src/pacemaker.rs
@@ -5,15 +5,11 @@
 
 //! [Trait definition](Pacemaker) for pacemakers: user-provided types that determine the 'liveness' behavior of replicas.
 //!
-//! Specifically, pacemakers tell replica code four things:
+//! Specifically, pacemakers tell replica code two things:
 //! 1. [View timeout](Pacemaker::view_timeout): given the current view, and the highest view I (the replica) has seen
 //!    consensus progress, how long should I stay in the current view to wait for messages?
 //! 2. [View leader](Pacemaker::view_leader): given the current view, and the current validator set, who should I consider
 //!    the current leader?
-//! 3. [Sync request limit](Pacemaker::sync_request_limit): when I'm syncing, how many blocks should I request my sync peer
-//!    send in a single response?
-//! 4. [Sync response timeout](Pacemaker::sync_response_timeout): how long should I wait for a response to a sync request
-//!    that I make?
 
 use crate::types::*;
 use std::cmp::min;
@@ -22,7 +18,7 @@ use std::time::Duration;
 
 /// # Safety
 ///
-/// Durations returned by [Pacemaker::view_timeout] and [Pacemaker::sync_response_timeout] must be "well below"
+/// Durations returned by [Pacemaker::view_timeout] must be "well below"
 /// [u64::MAX] seconds. A good limit is to cap them at [u32::MAX].
 ///
 /// In the most popular target platforms, Durations can only go up to [u64::MAX] seconds, so keeping returned
@@ -46,9 +42,7 @@ pub struct DefaultPacemaker {
 
 impl DefaultPacemaker {
     /// # Safety
-    ///
-    /// `minimum_view_timeout` and `sync_response_timeout` must not be larger than [u32::MAX] seconds for reasons
-    /// explained in [Pacemaker].
+    /// `minimum_view_timeout` must not be larger than [u32::MAX] seconds for reasons explained in [Pacemaker].
     pub fn new(minimum_view_timeout: Duration) -> DefaultPacemaker {
         Self {
             minimum_view_timeout,

--- a/src/pacemaker.rs
+++ b/src/pacemaker.rs
@@ -35,7 +35,7 @@ pub trait Pacemaker: Send {
     ) -> Duration;
 
     fn view_leader(&mut self, cur_view: ViewNumber, validator_set: &ValidatorSet)
-        -> PublicKeyBytes;
+        -> PublicKey;
 
     fn sync_request_limit(&self) -> u32;
 
@@ -73,7 +73,7 @@ impl Pacemaker for DefaultPacemaker {
         &mut self,
         cur_view: ViewNumber,
         validator_set: &ValidatorSet,
-    ) -> PublicKeyBytes {
+    ) -> PublicKey {
         let num_validators = validator_set.len();
         *validator_set
             .validators()

--- a/src/pacemaker.rs
+++ b/src/pacemaker.rs
@@ -35,7 +35,7 @@ pub trait Pacemaker: Send {
     ) -> Duration;
 
     fn view_leader(&mut self, cur_view: ViewNumber, validator_set: &ValidatorSet)
-        -> PublicKey;
+        -> VerifyingKey;
 }
 
 /// A pacemaker which selects leaders in a round-robin fashion, and prescribes exponentially increasing view timeouts to
@@ -61,7 +61,7 @@ impl Pacemaker for DefaultPacemaker {
         &mut self,
         cur_view: ViewNumber,
         validator_set: &ValidatorSet,
-    ) -> PublicKey {
+    ) -> VerifyingKey {
         let num_validators = validator_set.len();
         *validator_set
             .validators()

--- a/src/pacemaker.rs
+++ b/src/pacemaker.rs
@@ -11,10 +11,11 @@
 //! 2. [View leader](Pacemaker::view_leader): given the current view, and the current validator set, who should I consider
 //!    the current leader?
 
-use crate::types::*;
 use std::cmp::min;
 use std::convert::identity;
 use std::time::Duration;
+
+use crate::types::*;
 
 /// # Safety
 ///

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -34,8 +34,7 @@ use crate::networking::{
 use crate::pacemaker::Pacemaker;
 use crate::state::{BlockTree, BlockTreeCamera, KVStore};
 use crate::sync_server::start_sync_server;
-use crate::types::ChainID;
-use crate::types::{AppStateUpdates, ValidatorSetUpdates, SigningKey};
+use crate::types::{AppStateUpdates, ValidatorSetUpdates, SigningKey, ChainID};
 use std::sync::mpsc::{self, Sender};
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -53,7 +52,7 @@ pub struct Configuration {
 }
 
 #[derive(TypedBuilder)]
-pub struct ReplicaBuilder<K: KVStore, A: App<K> + 'static, N: Network + 'static, P: Pacemaker + 'static> {
+pub struct ReplicaSpec<K: KVStore, A: App<K> + 'static, N: Network + 'static, P: Pacemaker + 'static> {
     // Required parameters
     app: A,
     network: N,
@@ -105,7 +104,7 @@ pub struct ReplicaBuilder<K: KVStore, A: App<K> + 'static, N: Network + 'static,
     on_send_sync_response: Vec<HandlerPtr<SendSyncResponseEvent>>,
 }
 
-impl<K: KVStore, A: App<K> + 'static, N: Network + 'static, P: Pacemaker + 'static> ReplicaBuilder<K, A, N, P> {
+impl<K: KVStore, A: App<K> + 'static, N: Network + 'static, P: Pacemaker + 'static> ReplicaSpec<K, A, N, P> {
 
     pub fn start(mut self) -> Replica<K> {
         let block_tree = BlockTree::new(self.kv_store.clone());
@@ -184,9 +183,9 @@ impl<K: KVStore, A: App<K> + 'static, N: Network + 'static, P: Pacemaker + 'stat
         let event_bus = if !event_handlers.is_empty() {
             Some(
                 start_event_bus(
-                event_handlers,
-                event_subscriber.unwrap(), // Safety: should be Some(...)
-                event_bus_shutdown_receiver.unwrap(), // Safety: should be Some(...)
+                    event_handlers,
+                    event_subscriber.unwrap(), // Safety: should be Some(...)
+                    event_bus_shutdown_receiver.unwrap(), // Safety: should be Some(...)
                 )
             )
         } else {

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -20,7 +20,7 @@
 //! 
 //! Here is an example that demonstrates how to build and start running a replica using the builder pattern:
 //! 
-//! ```
+//! ```rust,ignore
 //! let replica =
 //!     ReplicaSpec :: builder()
 //!     .app(app)
@@ -66,7 +66,7 @@
 //! 
 //! The replica's [configuration](Configuration) can also be defined using the builder pattern, for example:
 //! 
-//! ```
+//! ```rust, ignore
 //! let configuration = 
 //!     Configuration :: builder()
 //!     .me(keypair)

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -34,6 +34,7 @@ use crate::networking::{
 use crate::pacemaker::Pacemaker;
 use crate::state::{BlockTree, BlockTreeCamera, KVStore};
 use crate::sync_server::start_sync_server;
+use crate::types::ChainID;
 use crate::types::{AppStateUpdates, ValidatorSetUpdates, SigningKey};
 use std::sync::mpsc::{self, Sender};
 use std::thread::JoinHandle;
@@ -43,6 +44,7 @@ use typed_builder::TypedBuilder;
 #[derive(TypedBuilder)]
 pub struct Configuration {
     pub me: SigningKey,
+    pub chain_id: ChainID,
     pub sync_trigger_timeout: Duration,
     pub sync_request_limit: u32,
     pub sync_response_timeout: Duration,
@@ -162,6 +164,7 @@ impl<K: KVStore, A: App<K> + 'static, N: Network + 'static, P: Pacemaker + 'stat
         let algorithm = start_algorithm(
             self.app,
             messages::Keypair::new(self.configuration.me),
+            self.configuration.chain_id,
             block_tree,
             self.pacemaker,
             pm_stub,

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -44,7 +44,6 @@ use typed_builder::TypedBuilder;
 pub struct Configuration {
     pub me: SigningKey,
     pub chain_id: ChainID,
-    pub sync_trigger_timeout: Duration,
     pub sync_request_limit: u32,
     pub sync_response_timeout: Duration,
     pub progress_msg_buffer_capacity: u64,
@@ -169,7 +168,6 @@ impl<K: KVStore, A: App<K> + 'static, N: Network + 'static, P: Pacemaker + 'stat
             event_publisher,
             self.configuration.sync_request_limit,
             self.configuration.sync_response_timeout,
-            self.configuration.sync_trigger_timeout
         );
 
         let (event_bus_shutdown, event_bus_shutdown_receiver) =

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -60,48 +60,48 @@ pub struct ReplicaSpec<K: KVStore, A: App<K> + 'static, N: Network + 'static, P:
     pacemaker: P,
     configuration: Configuration,
     // Optional parameters
-    #[builder(default, setter(transform = |handler: impl Fn(&InsertBlockEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<InsertBlockEvent>]))]
-    on_insert_block: Vec<HandlerPtr<InsertBlockEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&CommitBlockEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<CommitBlockEvent>]))]
-    on_commit_block: Vec<HandlerPtr<CommitBlockEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&PruneBlockEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<PruneBlockEvent>]))]
-    on_prune_block: Vec<HandlerPtr<PruneBlockEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&UpdateHighestQCEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<UpdateHighestQCEvent>]))]
-    on_update_highest_qc: Vec<HandlerPtr<UpdateHighestQCEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&UpdateLockedViewEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<UpdateLockedViewEvent>]))]
-    on_update_locked_view: Vec<HandlerPtr<UpdateLockedViewEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&UpdateValidatorSetEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<UpdateValidatorSetEvent>]))]
-    on_update_validator_set: Vec<HandlerPtr<UpdateValidatorSetEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&ProposeEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<ProposeEvent>]))]
-    on_propose: Vec<HandlerPtr<ProposeEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&NudgeEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<NudgeEvent>]))]
-    on_nudge: Vec<HandlerPtr<NudgeEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&VoteEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<VoteEvent>]))]
-    on_vote: Vec<HandlerPtr<VoteEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&NewViewEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<NewViewEvent>]))]
-    on_new_view: Vec<HandlerPtr<NewViewEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveProposalEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<ReceiveProposalEvent>]))]
-    on_receive_proposal: Vec<HandlerPtr<ReceiveProposalEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveNudgeEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<ReceiveNudgeEvent>]))]
-    on_receive_nudge: Vec<HandlerPtr<ReceiveNudgeEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveVoteEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<ReceiveVoteEvent>]))]
-    on_receive_vote: Vec<HandlerPtr<ReceiveVoteEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveNewViewEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<ReceiveNewViewEvent>]))]
-    on_receive_new_view: Vec<HandlerPtr<ReceiveNewViewEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&StartViewEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<StartViewEvent>]))]
-    on_start_view: Vec<HandlerPtr<StartViewEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&ViewTimeoutEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<ViewTimeoutEvent>]))]
-    on_view_timeout: Vec<HandlerPtr<ViewTimeoutEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&CollectQCEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<CollectQCEvent>]))]
-    on_collect_qc: Vec<HandlerPtr<CollectQCEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&StartSyncEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<StartSyncEvent>]))]
-    on_start_sync: Vec<HandlerPtr<StartSyncEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&EndSyncEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<EndSyncEvent>]))]
-    on_end_sync: Vec<HandlerPtr<EndSyncEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveSyncRequestEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<ReceiveSyncRequestEvent>]))]
-    on_receive_sync_request: Vec<HandlerPtr<ReceiveSyncRequestEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&SendSyncResponseEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<SendSyncResponseEvent>]))]
-    on_send_sync_response: Vec<HandlerPtr<SendSyncResponseEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&InsertBlockEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<InsertBlockEvent>)))]
+    on_insert_block: Option<HandlerPtr<InsertBlockEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&CommitBlockEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<CommitBlockEvent>)))]
+    on_commit_block: Option<HandlerPtr<CommitBlockEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&PruneBlockEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<PruneBlockEvent>)))]
+    on_prune_block: Option<HandlerPtr<PruneBlockEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&UpdateHighestQCEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<UpdateHighestQCEvent>)))]
+    on_update_highest_qc: Option<HandlerPtr<UpdateHighestQCEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&UpdateLockedViewEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<UpdateLockedViewEvent>)))]
+    on_update_locked_view: Option<HandlerPtr<UpdateLockedViewEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&UpdateValidatorSetEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<UpdateValidatorSetEvent>)))]
+    on_update_validator_set: Option<HandlerPtr<UpdateValidatorSetEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&ProposeEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ProposeEvent>)))]
+    on_propose: Option<HandlerPtr<ProposeEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&NudgeEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<NudgeEvent>)))]
+    on_nudge: Option<HandlerPtr<NudgeEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&VoteEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<VoteEvent>)))]
+    on_vote: Option<HandlerPtr<VoteEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&NewViewEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<NewViewEvent>)))]
+    on_new_view: Option<HandlerPtr<NewViewEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveProposalEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ReceiveProposalEvent>)))]
+    on_receive_proposal: Option<HandlerPtr<ReceiveProposalEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveNudgeEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ReceiveNudgeEvent>)))]
+    on_receive_nudge: Option<HandlerPtr<ReceiveNudgeEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveVoteEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ReceiveVoteEvent>)))]
+    on_receive_vote: Option<HandlerPtr<ReceiveVoteEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveNewViewEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ReceiveNewViewEvent>)))]
+    on_receive_new_view: Option<HandlerPtr<ReceiveNewViewEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&StartViewEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<StartViewEvent>)))]
+    on_start_view: Option<HandlerPtr<StartViewEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&ViewTimeoutEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ViewTimeoutEvent>)))]
+    on_view_timeout: Option<HandlerPtr<ViewTimeoutEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&CollectQCEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<CollectQCEvent>)))]
+    on_collect_qc: Option<HandlerPtr<CollectQCEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&StartSyncEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<StartSyncEvent>)))]
+    on_start_sync: Option<HandlerPtr<StartSyncEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&EndSyncEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<EndSyncEvent>)))]
+    on_end_sync: Option<HandlerPtr<EndSyncEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveSyncRequestEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ReceiveSyncRequestEvent>)))]
+    on_receive_sync_request: Option<HandlerPtr<ReceiveSyncRequestEvent>>,
+    #[builder(default, setter(transform = |handler: impl Fn(&SendSyncResponseEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<SendSyncResponseEvent>)))]
+    on_send_sync_response: Option<HandlerPtr<SendSyncResponseEvent>>,
 }
 
 impl<K: KVStore, A: App<K> + 'static, N: Network + 'static, P: Pacemaker + 'static> ReplicaSpec<K, A, N, P> {
@@ -117,33 +117,30 @@ impl<K: KVStore, A: App<K> + 'static, N: Network + 'static, P: Pacemaker + 'stat
         let sync_server_stub = SyncServerStub::new(sync_requests, self.network.clone());
         let sync_client_stub = SyncClientStub::new(self.network, sync_responses);
 
-        let mut event_handlers = EventHandlers {
-            insert_block_handlers: self.on_insert_block,
-            commit_block_handlers: self.on_commit_block,
-            prune_block_handlers: self.on_prune_block,
-            update_highest_qc_handlers: self.on_update_highest_qc,
-            update_locked_view_handlers: self.on_update_locked_view,
-            update_validator_set_handlers: self.on_update_validator_set,
-            propose_handlers: self.on_propose,
-            nudge_handlers: self.on_nudge,
-            vote_handlers: self.on_vote,
-            new_view_handlers: self.on_new_view,
-            receive_proposal_handlers: self.on_receive_proposal,
-            receive_nudge_handlers: self.on_receive_nudge,
-            receive_vote_handlers: self.on_receive_vote,
-            receive_new_view_handlers: self.on_receive_new_view,
-            start_view_handlers: self.on_start_view,
-            view_timeout_handlers: self.on_view_timeout,
-            collect_qc_handlers: self.on_collect_qc,
-            start_sync_handlers: self.on_start_sync,
-            end_sync_handlers: self.on_end_sync,
-            receive_sync_request_handlers: self.on_receive_sync_request,
-            send_sync_response_handlers: self.on_send_sync_response
-        };
-
-        if self.configuration.log_events {
-            event_handlers.add_logging_handlers();
-        };
+        let event_handlers = EventHandlers::new(
+            self.configuration.log_events,
+            self.on_insert_block,
+            self.on_commit_block,
+            self.on_prune_block,
+            self.on_update_highest_qc,
+            self.on_update_locked_view,
+            self.on_update_validator_set,
+            self.on_propose,
+            self.on_nudge,
+            self.on_vote,
+            self.on_new_view,
+            self.on_receive_proposal,
+            self.on_receive_nudge,
+            self.on_receive_vote,
+            self.on_receive_new_view,
+            self.on_start_view,
+            self.on_view_timeout,
+            self.on_collect_qc,
+            self.on_start_sync,
+            self.on_end_sync,
+            self.on_receive_sync_request,
+            self.on_send_sync_response
+        );
 
         let (event_publisher, event_subscriber) = 
             if !event_handlers.is_empty() {

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -41,65 +41,99 @@ use std::time::Duration;
 use typed_builder::TypedBuilder;
 
 #[derive(TypedBuilder)]
+#[builder(doc)]
 pub struct Configuration {
+    #[builder(setter(doc = "Sets the replica's keypair, used to sign messages. Required."))]
     pub me: SigningKey,
+    #[builder(setter(doc = "Sets the chain ID of the blockchain. Required."))]
     pub chain_id: ChainID,
+    #[builder(setter(doc = "Sets the limit for the number of blocks that can be sent from the replica's sync server to a syncing peer. Required."))]
     pub sync_request_limit: u32,
+    #[builder(setter(doc = "Sets the timeout for receiving sync responses from a peer (in seconds). Required."))]
     pub sync_response_timeout: Duration,
+    #[builder(setter(doc = "Sets the maximum number of bytes that can be stored in the replica's message buffer at any given moment. Required."))]
     pub progress_msg_buffer_capacity: u64,
+    #[builder(setter(doc = "Enables/disables logging. Required."))]
     pub log_events: bool,
 }
 
 #[derive(TypedBuilder)]
+#[builder(doc)]
 pub struct ReplicaSpec<K: KVStore, A: App<K> + 'static, N: Network + 'static, P: Pacemaker + 'static> {
     // Required parameters
+    #[builder(setter(doc = "Sets the application code to be run on the blockchain. The argument must implement the App trait. This setter is required to start a replica."))]
     app: A,
+    #[builder(setter(doc = "Sets the implementation of peer-to-peer networking. The argument must implement the Network trait. This setter is required to start a replica."))]
     network: N,
+    #[builder(setter(doc = "Sets the implementation of the replica's Key-Value store. The argument must implement the KVStore trait. This setter is required to start a replica."))]
     kv_store: K,
+    #[builder(setter(doc = "Sets the implementation of the pacemaker. The argument must implement the Pacemaker trait. This setter is required to start a replica."))]
     pacemaker: P,
+    #[builder(setter(doc = "Sets the configuration, which contains the necessary parameters to run a replica. This setter is required to start a replica."))]
     configuration: Configuration,
     // Optional parameters
-    #[builder(default, setter(transform = |handler: impl Fn(&InsertBlockEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<InsertBlockEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&InsertBlockEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<InsertBlockEvent>),
+    doc = "Registers a handler closure to be invoked after a block is inserted to the replica's BlockTree. This setter is optional."))]
     on_insert_block: Option<HandlerPtr<InsertBlockEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&CommitBlockEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<CommitBlockEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&CommitBlockEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<CommitBlockEvent>),
+    doc = "Registers a handler closure to be invoked after a block is committed. This setter is optional."))]
     on_commit_block: Option<HandlerPtr<CommitBlockEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&PruneBlockEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<PruneBlockEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&PruneBlockEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<PruneBlockEvent>),
+    doc = "Registers a handler closure to be invoked after a block is pruned, i.e., its siblings are removed from the replica's BlockTree. This setter is optional."))]
     on_prune_block: Option<HandlerPtr<PruneBlockEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&UpdateHighestQCEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<UpdateHighestQCEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&UpdateHighestQCEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<UpdateHighestQCEvent>),
+    doc = "Registers a handler closure to be invoked after the replica updates its highest QC. This setter is optional."))]
     on_update_highest_qc: Option<HandlerPtr<UpdateHighestQCEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&UpdateLockedViewEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<UpdateLockedViewEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&UpdateLockedViewEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<UpdateLockedViewEvent>),
+    doc = "Registers a handler closure to be invoked after the replica updates its locked view. This setter is optional."))]
     on_update_locked_view: Option<HandlerPtr<UpdateLockedViewEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&UpdateValidatorSetEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<UpdateValidatorSetEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&UpdateValidatorSetEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<UpdateValidatorSetEvent>),
+    doc = "Registers a handler closure to be invoked after the replica updates its validator set. This setter is optional."))]
     on_update_validator_set: Option<HandlerPtr<UpdateValidatorSetEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&ProposeEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ProposeEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&ProposeEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ProposeEvent>),
+    doc = "Registers a handler closure to be invoked after the replica broadcasts a proposal for a block. This setter is optional."))]
     on_propose: Option<HandlerPtr<ProposeEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&NudgeEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<NudgeEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&NudgeEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<NudgeEvent>),
+    doc = "Registers a handler closure to be invoked after the replica broadcasts a nudge for a block. This setter is optional."))]
     on_nudge: Option<HandlerPtr<NudgeEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&VoteEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<VoteEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&VoteEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<VoteEvent>),
+    doc = "Registers a handler closure to be invoked after the replica sends a vote. This setter is optional."))]
     on_vote: Option<HandlerPtr<VoteEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&NewViewEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<NewViewEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&NewViewEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<NewViewEvent>),
+    doc = "Registers a handler closure to be invoked after the replica sends a new view message to the next leader. This setter is optional."))]
     on_new_view: Option<HandlerPtr<NewViewEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveProposalEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ReceiveProposalEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveProposalEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ReceiveProposalEvent>),
+    doc = "Registers a handler closure to be invoked after the replica receives a proposal for a block. This setter is optional."))]
     on_receive_proposal: Option<HandlerPtr<ReceiveProposalEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveNudgeEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ReceiveNudgeEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveNudgeEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ReceiveNudgeEvent>),
+    doc = "Registers a handler closure to be invoked after the replica receives a nudge for a block. This setter is optional."))]
     on_receive_nudge: Option<HandlerPtr<ReceiveNudgeEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveVoteEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ReceiveVoteEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveVoteEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ReceiveVoteEvent>),
+    doc = "Registers a handler closure to be invoked after the replica receives a vote. This setter is optional."))]
     on_receive_vote: Option<HandlerPtr<ReceiveVoteEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveNewViewEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ReceiveNewViewEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveNewViewEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ReceiveNewViewEvent>),
+    doc = "Registers a handler closure to be invoked after the replica receives a new view message. This setter is optional."))]
     on_receive_new_view: Option<HandlerPtr<ReceiveNewViewEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&StartViewEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<StartViewEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&StartViewEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<StartViewEvent>),
+    doc = "Registers a handler closure to be invoked after the replica enters a new view. This setter is optional."))]
     on_start_view: Option<HandlerPtr<StartViewEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&ViewTimeoutEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ViewTimeoutEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&ViewTimeoutEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ViewTimeoutEvent>),
+    doc = "Registers a handler closure to be invoked after the replica's view times out. This setter is optional."))]
     on_view_timeout: Option<HandlerPtr<ViewTimeoutEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&CollectQCEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<CollectQCEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&CollectQCEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<CollectQCEvent>),
+    doc = "Registers a handler closure to be invoked after the replica collects a new quorum certificate. This setter is optional."))]
     on_collect_qc: Option<HandlerPtr<CollectQCEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&StartSyncEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<StartSyncEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&StartSyncEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<StartSyncEvent>),
+    doc = "Registers a handler closure to be invoked after the replica starts syncing, exiting the progress mode. This setter is optional."))]
     on_start_sync: Option<HandlerPtr<StartSyncEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&EndSyncEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<EndSyncEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&EndSyncEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<EndSyncEvent>),
+    doc = "Registers a handler closure to be invoked after the replica finishes syncing, returning to progress mode. This setter is optional."))]
     on_end_sync: Option<HandlerPtr<EndSyncEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveSyncRequestEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ReceiveSyncRequestEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveSyncRequestEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<ReceiveSyncRequestEvent>),
+    doc = "Registers a handler closure to be invoked after the replica receives a sync request from a peer. This setter is optional."))]
     on_receive_sync_request: Option<HandlerPtr<ReceiveSyncRequestEvent>>,
-    #[builder(default, setter(transform = |handler: impl Fn(&SendSyncResponseEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<SendSyncResponseEvent>)))]
+    #[builder(default, setter(transform = |handler: impl Fn(&SendSyncResponseEvent) + Send + 'static| Some(Box::new(handler) as HandlerPtr<SendSyncResponseEvent>),
+    doc = "Registers a handler closure to be invoked after the replica sends a sync response to a peer. This setter is optional."))]
     on_send_sync_response: Option<HandlerPtr<SendSyncResponseEvent>>,
 }
 

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -32,8 +32,7 @@ use crate::networking::{
 use crate::pacemaker::Pacemaker;
 use crate::state::{BlockTree, BlockTreeCamera, KVStore};
 use crate::sync_server::start_sync_server;
-use crate::types::{AppStateUpdates, ValidatorSetUpdates};
-use ed25519_dalek::Keypair;
+use crate::types::{AppStateUpdates, ValidatorSetUpdates, PrivateKey};
 use std::sync::mpsc::{self, Sender};
 use std::thread::JoinHandle;
 
@@ -59,7 +58,7 @@ impl<K: KVStore> Replica<K> {
 
     pub fn start(
         app: impl App<K> + 'static,
-        keypair: Keypair,
+        private_key: PrivateKey,
         mut network: impl Network + 'static,
         kv_store: K,
         pacemaker: impl Pacemaker + 'static,
@@ -85,7 +84,7 @@ impl<K: KVStore> Replica<K> {
         let (algorithm_shutdown, algorithm_shutdown_receiver) = mpsc::channel();
         let algorithm = start_algorithm(
             app,
-            messages::Keypair::new(keypair),
+            messages::Keypair::new(private_key),
             block_tree,
             pacemaker,
             pm_stub,

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -172,7 +172,8 @@ impl<K: KVStore, A: App<K> + 'static, N: Network + 'static, P: Pacemaker + 'stat
             algorithm_shutdown_receiver,
             event_publisher,
             self.configuration.sync_request_limit,
-            self.configuration.sync_response_timeout
+            self.configuration.sync_response_timeout,
+            self.configuration.sync_trigger_timeout
         );
 
         let (event_bus_shutdown, event_bus_shutdown_receiver) =

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -8,7 +8,7 @@
 //!
 //! HotStuff-rs works to safely replicate a state machine in multiple processes. In our terminology, these processes are
 //! called 'replicas', and therefore the set of all replicas is called the 'replica set'. Each replica is uniquely identified
-//! by an Ed25519 public key.
+//! by an Ed25519 public key (ed25519-dalek::VerifyingKey).
 //!
 //! ## Validators and Listeners
 //!

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -218,9 +218,10 @@ impl<K: KVStore> Replica<K> {
         kv_store: K,
         initial_app_state: AppStateUpdates,
         initial_validator_set: ValidatorSetUpdates,
+        chain_id: ChainID
     ) {
         let mut block_tree = BlockTree::new(kv_store);
-        block_tree.initialize(&initial_app_state, &initial_validator_set);
+        block_tree.initialize(&initial_app_state, &initial_validator_set, chain_id);
     }
 
     pub fn block_tree_camera(&self) -> &BlockTreeCamera<K> {

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -60,47 +60,47 @@ pub struct ReplicaSpec<K: KVStore, A: App<K> + 'static, N: Network + 'static, P:
     pacemaker: P,
     configuration: Configuration,
     // Optional parameters
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<InsertBlockEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&InsertBlockEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<InsertBlockEvent>]))]
     on_insert_block: Vec<HandlerPtr<InsertBlockEvent>>,
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<CommitBlockEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&CommitBlockEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<CommitBlockEvent>]))]
     on_commit_block: Vec<HandlerPtr<CommitBlockEvent>>,
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<PruneBlockEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&PruneBlockEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<PruneBlockEvent>]))]
     on_prune_block: Vec<HandlerPtr<PruneBlockEvent>>,
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<UpdateHighestQCEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&UpdateHighestQCEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<UpdateHighestQCEvent>]))]
     on_update_highest_qc: Vec<HandlerPtr<UpdateHighestQCEvent>>,
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<UpdateLockedViewEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&UpdateLockedViewEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<UpdateLockedViewEvent>]))]
     on_update_locked_view: Vec<HandlerPtr<UpdateLockedViewEvent>>,
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<UpdateValidatorSetEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&UpdateValidatorSetEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<UpdateValidatorSetEvent>]))]
     on_update_validator_set: Vec<HandlerPtr<UpdateValidatorSetEvent>>,
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<ProposeEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&ProposeEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<ProposeEvent>]))]
     on_propose: Vec<HandlerPtr<ProposeEvent>>,
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<NudgeEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&NudgeEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<NudgeEvent>]))]
     on_nudge: Vec<HandlerPtr<NudgeEvent>>,
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<VoteEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&VoteEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<VoteEvent>]))]
     on_vote: Vec<HandlerPtr<VoteEvent>>,
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<NewViewEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&NewViewEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<NewViewEvent>]))]
     on_new_view: Vec<HandlerPtr<NewViewEvent>>,
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<ReceiveProposalEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveProposalEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<ReceiveProposalEvent>]))]
     on_receive_proposal: Vec<HandlerPtr<ReceiveProposalEvent>>,
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<ReceiveNudgeEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveNudgeEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<ReceiveNudgeEvent>]))]
     on_receive_nudge: Vec<HandlerPtr<ReceiveNudgeEvent>>,
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<ReceiveVoteEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveVoteEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<ReceiveVoteEvent>]))]
     on_receive_vote: Vec<HandlerPtr<ReceiveVoteEvent>>,
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<ReceiveNewViewEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveNewViewEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<ReceiveNewViewEvent>]))]
     on_receive_new_view: Vec<HandlerPtr<ReceiveNewViewEvent>>,
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<StartViewEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&StartViewEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<StartViewEvent>]))]
     on_start_view: Vec<HandlerPtr<StartViewEvent>>,
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<ViewTimeoutEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&ViewTimeoutEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<ViewTimeoutEvent>]))]
     on_view_timeout: Vec<HandlerPtr<ViewTimeoutEvent>>,
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<CollectQCEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&CollectQCEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<CollectQCEvent>]))]
     on_collect_qc: Vec<HandlerPtr<CollectQCEvent>>,
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<StartSyncEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&StartSyncEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<StartSyncEvent>]))]
     on_start_sync: Vec<HandlerPtr<StartSyncEvent>>,
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<EndSyncEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&EndSyncEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<EndSyncEvent>]))]
     on_end_sync: Vec<HandlerPtr<EndSyncEvent>>,
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<ReceiveSyncRequestEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&ReceiveSyncRequestEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<ReceiveSyncRequestEvent>]))]
     on_receive_sync_request: Vec<HandlerPtr<ReceiveSyncRequestEvent>>,
-    #[builder(default = Vec::with_capacity(1), setter(transform = |handler_ptr: HandlerPtr<SendSyncResponseEvent>| vec![handler_ptr]))]
+    #[builder(default, setter(transform = |handler: impl Fn(&SendSyncResponseEvent) + Send + 'static| vec![Box::new(handler) as HandlerPtr<SendSyncResponseEvent>]))]
     on_send_sync_response: Vec<HandlerPtr<SendSyncResponseEvent>>,
 }
 

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -218,10 +218,9 @@ impl<K: KVStore> Replica<K> {
         kv_store: K,
         initial_app_state: AppStateUpdates,
         initial_validator_set: ValidatorSetUpdates,
-        chain_id: ChainID
     ) {
         let mut block_tree = BlockTree::new(kv_store);
-        block_tree.initialize(&initial_app_state, &initial_validator_set, chain_id);
+        block_tree.initialize(&initial_app_state, &initial_validator_set);
     }
 
     pub fn block_tree_camera(&self) -> &BlockTreeCamera<K> {

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -23,6 +23,11 @@
 //! messages to all peers it is connected to, and not only the validators. The library user is free to design and implement
 //! their own mechanism for deciding which peers, besides those in the validator set, should be connected to the network.
 
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use typed_builder::TypedBuilder;
+
 use crate::algorithm::start_algorithm;
 use crate::app::App;
 use crate::event_bus::*;
@@ -36,9 +41,6 @@ use crate::state::{BlockTree, BlockTreeCamera, KVStore};
 use crate::sync_server::start_sync_server;
 use crate::types::{AppStateUpdates, ValidatorSetUpdates, SigningKey, ChainID};
 use std::sync::mpsc::{self, Sender};
-use std::thread::JoinHandle;
-use std::time::Duration;
-use typed_builder::TypedBuilder;
 
 /// Stores the user-defined parameters required to start the replica, that is:
 /// 1. The replica's [keypair](ed25519_dalek::SigningKey).
@@ -47,14 +49,14 @@ use typed_builder::TypedBuilder;
 /// 4. The sync response timeout (in seconds), which defines the maximum amount of time after which the replica should wait for a sync response.
 /// 5. The progress message buffer capacity, which defines the maximum allowed capacity of the progress message buffer. If this capacity
 ///    is about to be exceeded, some messages might be removed to make space for new messages.
-/// 6. The "Log Events" flag, if true then logs should be printed. 
+/// 6. The "Log Events" flag, if set to "true" then logs should be printed. 
 /// 
 /// ## Chain ID
 /// 
 /// Each HotStuff-rs blockchain should be identified by a [chain ID](crate::types::ChainID). This
 /// is included in votes and other messages so that replicas don't mistake messages and blocks for
 /// one HotStuff-rs blockchain does not get mistaken for those for another blockchain.
-/// //! In most cases, having a chain ID that collides with another blockchain is harmless. But
+/// In most cases, having a chain ID that collides with another blockchain is harmless. But
 /// if your application is a Proof of Stake public blockchain, this may cause a slashable offence
 /// if you operate validators in two chains that use the same keypair. So ensure that you don't
 /// operate a validator in two blockchains with the same keypair.
@@ -79,9 +81,9 @@ pub struct Configuration {
     pub me: SigningKey,
     #[builder(setter(doc = "Sets the chain ID of the blockchain. Required."))]
     pub chain_id: ChainID,
-    #[builder(setter(doc = "Sets the limit for the number of blocks that can be sent from the replica's sync server to a syncing peer. Required."))]
+    #[builder(setter(doc = "Sets the limit for the number of blocks that a replica can request from its peer when syncing. Required."))]
     pub sync_request_limit: u32,
-    #[builder(setter(doc = "Sets the timeout for receiving sync responses from a peer (in seconds). Required."))]
+    #[builder(setter(doc = "Sets the timeout for receiving a sync response from a peer (in seconds). Required."))]
     pub sync_response_timeout: Duration,
     #[builder(setter(doc = "Sets the maximum number of bytes that can be stored in the replica's message buffer at any given moment. Required."))]
     pub progress_msg_buffer_capacity: u64,

--- a/src/state.rs
+++ b/src/state.rs
@@ -408,6 +408,10 @@ impl<K: KVStore> BlockTree<K> {
         wb.delete_children(tail);
         wb.delete_pending_app_state_updates(tail);
         wb.delete_pending_validator_set_updates(tail);
+
+        if let Some(data_len) = self.block_data_len(tail) {
+            wb.delete_block(tail, data_len)
+        }
     }
 
     /* ↓↓↓ Extra state getters for convenience ↓↓↓ */

--- a/src/state.rs
+++ b/src/state.rs
@@ -75,6 +75,7 @@ impl<K: KVStore> BlockTree<K> {
         &mut self,
         initial_app_state: &AppStateUpdates,
         initial_validator_set: &ValidatorSetUpdates,
+        chain_id: ChainID
     ) {
         let mut wb = BlockTreeWriteBatch::new();
 
@@ -88,7 +89,7 @@ impl<K: KVStore> BlockTree<K> {
 
         wb.set_highest_view_entered(0);
 
-        wb.set_highest_qc(&QuorumCertificate::genesis_qc());
+        wb.set_highest_qc(&QuorumCertificate::genesis_qc(chain_id));
 
         self.write(wb);
     }
@@ -811,7 +812,7 @@ impl<S: KVGet> BlockTreeSnapshot<S> {
                     }
                 }
 
-                if block_justify == QuorumCertificate::genesis_qc() {
+                if block_justify == QuorumCertificate::genesis_qc(block_justify.chain_id) {
                     break;
                 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -10,7 +10,7 @@
 //! can provide a type that implements [KVStore]. This state can be mutated through an instance of [BlockTree],
 //! and read through an instance of [BlockTreeSnapshot], which can be created using [BlockTreeCamera].
 //!
-//! In normal operation, HotStuff-rs code will internally be making all writes to the Block Tree, and users can
+//! In normal operation, HotStuff-rs code will internally be making all writes to the [Block Tree](crate::state::BlockTree), and users can
 //! get a [BlockTreeCamera] using replica's [block_tree_camera](crate::replica::Replica::block_tree_camera) method.
 //!
 //! Sometimes, however, users may want to manually mutate the Block Tree, for example, to recover from an error
@@ -116,7 +116,7 @@ impl<K: KVStore> BlockTree<K> {
     /// locked view.
     ///
     /// For this, it is necessary that:
-    /// 1. Its chain ID matches the chain ID of the replica, or is the genesis qc
+    /// 1. Its chain ID matches the chain ID of the replica, or is the genesis qc.
     /// 2. It justifies a known block, or is the genesis qc.
     /// 3. Its view number is greater than or equal to locked view.
     /// 4. If it is a prepare, precommit, or commit qc, the block it justifies has pending validator state updates.
@@ -236,10 +236,10 @@ impl<K: KVStore> BlockTree<K> {
 
         publish_insert_block_events(event_publisher, block.clone(), update_highest_qc, update_locked_view, committed_blocks.clone());
 
-        /// Publish all events resulting from calling insert_block on a block, 
-        /// These events change persistent state, and always include InsertBlockEvent, 
-        /// possibly include: UpdateHighestQCEvent, UpdatedLockedViewEvent, PruneBlockEvent, CommitBlockEvent, UpdateValidatorSetEvent
-        /// Invariant: invoked immediately after the corresponding changes are written to the Block Tree
+        /// Publish all events resulting from calling [self::insert_block] on a block, 
+        /// These events change persistent state, and always include [InsertBlockEvent], 
+        /// possibly include: [UpdateHighestQCEvent], [UpdateLockedViewEvent], [PruneBlockEvent], [CommitBlockEvent], [UpdateValidatorSetEvent].
+        /// Invariant: this method is invoked immediately after the corresponding changes are written to the [BlockTree].
         fn publish_insert_block_events(
             event_publisher: &Option<Sender<Event>>,
             block: Block,
@@ -324,9 +324,9 @@ impl<K: KVStore> BlockTree<K> {
         let uncommitted_blocks_ordered_iter = uncommitted_blocks.iter().rev();
         
         // Helper closure that
-        // (1) commits block b, applying all related updates to the write batch
-        // (2) extends the vector of blocks committed so far (accumulator) with b together with the optional validator set updates associated with b
-        // (3) returns the extended vector of blocks committed so far (updated accumulator)
+        // (1) commits block b, applying all related updates to the write batch,
+        // (2) extends the vector of blocks committed so far (accumulator) with b together with the optional validator set updates associated with b,
+        // (3) returns the extended vector of blocks committed so far (updated accumulator).
         let commit = |mut committed_blocks: Vec<(CryptoHash, Option<ValidatorSetUpdates>)>, b: &CryptoHash| ->  Vec<(CryptoHash, Option<ValidatorSetUpdates>)>{
 
             let block_height = self.block_height(b).unwrap();
@@ -367,8 +367,8 @@ impl<K: KVStore> BlockTree<K> {
 
         // Iterate over the uncommitted blocks from oldest to newest, 
         // (1) applying related updates (by mutating the write batch), and
-        // (2) building up the vector of committed blocks (by pushing the newely committed blocks to the accumulator vector)
-        // Finally, return the accumulator
+        // (2) building up the vector of committed blocks (by pushing the newely committed blocks to the accumulator vector).
+        // Finally, return the accumulator.
         uncommitted_blocks_ordered_iter.fold(Vec::new(), commit)
 
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -50,12 +50,14 @@
 //! - **Highest View Entered** (initialized to 0).
 //! - **Highest Quorum Certificate** (initialized to [the genesis qc](QuorumCertificate::genesis_qc)).
 
-use crate::events::{Event, InsertBlockEvent, CommitBlockEvent, PruneBlockEvent, UpdateHighestQCEvent, UpdateLockedViewEvent, UpdateValidatorSetEvent};
-use crate::types::*;
-use borsh::{BorshDeserialize, BorshSerialize};
 use std::iter::successors;
 use std::sync::mpsc::Sender;
 use std::time::SystemTime;
+
+use borsh::{BorshDeserialize, BorshSerialize};
+
+use crate::events::{Event, InsertBlockEvent, CommitBlockEvent, PruneBlockEvent, UpdateHighestQCEvent, UpdateLockedViewEvent, UpdateValidatorSetEvent};
+use crate::types::*;
 
 /// A read and write handle into the block tree exclusively owned by the algorithm thread.
 pub struct BlockTree<K: KVStore>(K);
@@ -1001,7 +1003,7 @@ re_export_getters_from_block_tree_and_block_tree_snapshot!(
 
         fn committed_validator_set(&self) -> ValidatorSet {
             let validator_set_bytes = ValidatorSetBytes::deserialize(&mut &*self.get(&COMMITTED_VALIDATOR_SET).unwrap()).unwrap();
-            ValidatorSet::try_from(validator_set_bytes).unwrap() //error should not happen so we unwrap
+            ValidatorSet::try_from(validator_set_bytes).unwrap()
         }
 
         /* ↓↓↓ Pending Validator Set Updates */

--- a/src/state.rs
+++ b/src/state.rs
@@ -1007,9 +1007,8 @@ re_export_getters_from_block_tree_and_block_tree_snapshot!(
         /* ↓↓↓ Pending Validator Set Updates */
 
         fn pending_validator_set_updates(&self, block: &CryptoHash) -> Option<ValidatorSetUpdates> {
-            ValidatorSetUpdatesBytes::deserialize(&mut &*self.get(&combine(&PENDING_VALIDATOR_SET_UPDATES, block))?,)
-            .ok()
-            .map(|validator_set_updates_bytes| ValidatorSetUpdates::try_from(validator_set_updates_bytes).unwrap())
+            let validator_set_updates_bytes = ValidatorSetUpdatesBytes::deserialize(&mut &*self.get(&combine(&PENDING_VALIDATOR_SET_UPDATES, block))?,).unwrap();
+            Some(ValidatorSetUpdates::try_from(validator_set_updates_bytes).unwrap())
         }
 
         /* ↓↓↓ Locked View ↓↓↓ */

--- a/src/state.rs
+++ b/src/state.rs
@@ -254,23 +254,30 @@ impl<K: KVStore> BlockTree<K> {
         update_locked_view: Option<ViewNumber>,
         committed_blocks: Vec<(CryptoHash, Option<ValidatorSetUpdates>)>
     ) {
-        Event::publish(event_publisher, Event::InsertBlock(InsertBlockEvent { timestamp: SystemTime::now(), block}));
+        Event::InsertBlock(InsertBlockEvent { timestamp: SystemTime::now(), block}).publish(event_publisher);
 
         if let Some(highest_qc) = update_highest_qc {
-            Event::publish(event_publisher, Event::UpdateHighestQC(UpdateHighestQCEvent { timestamp: SystemTime::now(), highest_qc}))
+            Event::UpdateHighestQC(UpdateHighestQCEvent { timestamp: SystemTime::now(), highest_qc}).publish(event_publisher)
         };
 
         if let Some(locked_view) = update_locked_view {
-            Event::publish(event_publisher, Event::UpdateLockedView(UpdateLockedViewEvent { timestamp: SystemTime::now(), locked_view}))
+            Event::UpdateLockedView(UpdateLockedViewEvent { timestamp: SystemTime::now(), locked_view}).publish(event_publisher)
         };
 
         committed_blocks
         .iter()
         .for_each(|(b, validator_set_updates_opt)| {
-            Event::publish(event_publisher, Event::PruneBlock(PruneBlockEvent { timestamp: SystemTime::now(), block: *b}));
-            Event::publish(event_publisher, Event::CommitBlock(CommitBlockEvent { timestamp: SystemTime::now(), block: *b}));
+            Event::PruneBlock(PruneBlockEvent { timestamp: SystemTime::now(), block: *b}).publish(event_publisher);
+            Event::CommitBlock(CommitBlockEvent { timestamp: SystemTime::now(), block: *b}).publish(event_publisher);
             if let Some(validator_set_updates) = validator_set_updates_opt {
-                Event::publish(event_publisher, Event::UpdateValidatorSet(UpdateValidatorSetEvent { timestamp: SystemTime::now(), cause_block: *b, validator_set_updates: validator_set_updates.clone()}));
+                Event::UpdateValidatorSet(UpdateValidatorSetEvent 
+                    { 
+                      timestamp: SystemTime::now(),
+                      cause_block: *b,
+                      validator_set_updates: validator_set_updates.clone()
+                    }
+                )
+                .publish(event_publisher);
             }
         });
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -75,7 +75,6 @@ impl<K: KVStore> BlockTree<K> {
         &mut self,
         initial_app_state: &AppStateUpdates,
         initial_validator_set: &ValidatorSetUpdates,
-        chain_id: ChainID
     ) {
         let mut wb = BlockTreeWriteBatch::new();
 
@@ -89,7 +88,7 @@ impl<K: KVStore> BlockTree<K> {
 
         wb.set_highest_view_entered(0);
 
-        wb.set_highest_qc(&QuorumCertificate::genesis_qc(chain_id));
+        wb.set_highest_qc(&QuorumCertificate::genesis_qc());
 
         self.write(wb);
     }
@@ -812,7 +811,7 @@ impl<S: KVGet> BlockTreeSnapshot<S> {
                     }
                 }
 
-                if block_justify == QuorumCertificate::genesis_qc(block_justify.chain_id) {
+                if block_justify == QuorumCertificate::genesis_qc() {
                     break;
                 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -116,7 +116,7 @@ impl<K: KVStore> BlockTree<K> {
     /// locked view.
     ///
     /// For this, it is necessary that:
-    /// 1. Its chain ID matches the chain ID of the replica
+    /// 1. Its chain ID matches the chain ID of the replica, or is the genesis qc
     /// 2. It justifies a known block, or is the genesis qc.
     /// 3. Its view number is greater than or equal to locked view.
     /// 4. If it is a prepare, precommit, or commit qc, the block it justifies has pending validator state updates.
@@ -126,7 +126,7 @@ impl<K: KVStore> BlockTree<K> {
     /// [QuorumCertificate::is_correct]
     pub fn safe_qc(&self, qc: &QuorumCertificate, chain_id: ChainID) -> bool {
         /* 1 */
-        qc.chain_id == chain_id &&
+        (qc.chain_id == chain_id || qc.is_genesis_qc()) &&
         /* 2 */
         (self.contains(&qc.block) || qc.is_genesis_qc()) &&
         /* 3 */ qc.view >= self.locked_view() &&

--- a/src/sync_server.rs
+++ b/src/sync_server.rs
@@ -59,7 +59,7 @@ pub(crate) fn start_sync_server<K: KVStore, N: Network + 'static>(
             },
         )) = sync_stub.recv_request()
         {
-            Event::publish(&event_publisher, Event::ReceiveSyncRequest(ReceiveSyncRequestEvent { timestamp: SystemTime::now(), peer: origin, start_height, limit}));
+            Event::ReceiveSyncRequest(ReceiveSyncRequestEvent { timestamp: SystemTime::now(), peer: origin, start_height, limit}).publish(&event_publisher);
 
             let bt_snapshot = block_tree.snapshot();
             let blocks = bt_snapshot
@@ -68,7 +68,7 @@ pub(crate) fn start_sync_server<K: KVStore, N: Network + 'static>(
 
             sync_stub.send_response(origin, SyncResponse { blocks: blocks.clone(), highest_qc: highest_qc.clone() });
 
-            Event::publish(&event_publisher, Event::SendSyncResponse(SendSyncResponseEvent { timestamp: SystemTime::now(), peer: origin, blocks, highest_qc}))
+            Event::SendSyncResponse(SendSyncResponseEvent { timestamp: SystemTime::now(), peer: origin, blocks, highest_qc}).publish(&event_publisher)
         }
         thread::yield_now();
     })

--- a/src/sync_server.rs
+++ b/src/sync_server.rs
@@ -35,6 +35,9 @@ use std::sync::mpsc::{Receiver, TryRecvError, Sender};
 use std::thread::{self, JoinHandle};
 use std::time::SystemTime;
 
+/// Starts the sync server thread, which runs an infinite loop until a shutdown signal is received.
+/// In each iteration of the loop the thread checks if it received any [sync requests](crate::messages::SyncRequest)
+/// from a peer, and proceeds accordingly to send a [sync response](crate::messages::SyncResponse).
 pub(crate) fn start_sync_server<K: KVStore, N: Network + 'static>(
     block_tree: BlockTreeCamera<K>,
     mut sync_stub: SyncServerStub<N>,

--- a/src/sync_server.rs
+++ b/src/sync_server.rs
@@ -26,14 +26,15 @@
 //!     - If it does contain new blocks, then the replica validates the blocks and quorum certificate and inserts them
 //!       into its block tree, and then jumps back to step 2.
 
-use crate::events::{Event, ReceiveSyncRequestEvent, SendSyncResponseEvent};
-use crate::messages::{SyncRequest, SyncResponse};
-use crate::networking::{Network, SyncServerStub};
-use crate::state::{BlockTreeCamera, KVStore};
 use std::cmp::max;
 use std::sync::mpsc::{Receiver, TryRecvError, Sender};
 use std::thread::{self, JoinHandle};
 use std::time::SystemTime;
+
+use crate::events::{Event, ReceiveSyncRequestEvent, SendSyncResponseEvent};
+use crate::messages::{SyncRequest, SyncResponse};
+use crate::networking::{Network, SyncServerStub};
+use crate::state::{BlockTreeCamera, KVStore};
 
 /// Starts the sync server thread, which runs an infinite loop until a shutdown signal is received.
 /// In each iteration of the loop the thread checks if it received any [sync requests](crate::messages::SyncRequest)

--- a/src/sync_server.rs
+++ b/src/sync_server.rs
@@ -39,7 +39,7 @@ pub(crate) fn start_sync_server<K: KVStore, N: Network + 'static>(
     block_tree: BlockTreeCamera<K>,
     mut sync_stub: SyncServerStub<N>,
     shutdown_signal: Receiver<()>,
-    server_sync_request_limit: u32,
+    sync_request_limit: u32,
     event_publisher: Option<Sender<Event>>,
 ) -> JoinHandle<()> {
     thread::spawn(move || loop {
@@ -63,7 +63,7 @@ pub(crate) fn start_sync_server<K: KVStore, N: Network + 'static>(
 
             let bt_snapshot = block_tree.snapshot();
             let blocks = bt_snapshot
-                .blocks_from_height_to_newest(start_height, max(limit, server_sync_request_limit));
+                .blocks_from_height_to_newest(start_height, max(limit, sync_request_limit));
             let highest_qc = bt_snapshot.highest_qc();
 
             sync_stub.send_response(origin, SyncResponse { blocks: blocks.clone(), highest_qc: highest_qc.clone() });

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,7 +13,7 @@ use sha2::Digest;
 use std::{
     collections::{hash_map, hash_set, HashMap, HashSet},
     hash::Hash,
-    slice,
+    slice, time::{Duration, Instant},
 };
 
 pub use ed25519_dalek::{SigningKey, VerifyingKey as PublicKey, Signature};
@@ -563,5 +563,28 @@ impl NewViewCollector {
         }
 
         self.accumulated_power >= QuorumCertificate::quorum(self.total_power)
+    }
+}
+
+pub struct SyncTriggerTimer {
+    last_update: Instant,
+    sync_trigger_timeout: Duration,
+}
+
+impl SyncTriggerTimer {
+
+    pub(crate) fn new(sync_trigger_timeout: Duration) -> SyncTriggerTimer {
+        Self {
+            last_update: Instant::now(),
+            sync_trigger_timeout
+        }
+    }
+
+    pub(crate) fn update(&mut self) {
+        self.last_update = Instant::now()
+    }
+
+    pub(crate) fn timeout(&self) -> bool {
+        Instant::now() - self.last_update >= self.sync_trigger_timeout
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -136,9 +136,9 @@ impl QuorumCertificate {
         }
     }
 
-    pub const fn genesis_qc() -> QuorumCertificate {
+    pub const fn genesis_qc(chain_id: ChainID) -> QuorumCertificate {
         QuorumCertificate {
-            chain_id: 0,
+            chain_id: chain_id,
             view: 0,
             block: [0u8; 32],
             phase: Phase::Generic,
@@ -147,7 +147,7 @@ impl QuorumCertificate {
     }
 
     pub fn is_genesis_qc(&self) -> bool {
-        *self == Self::genesis_qc()
+        *self == Self::genesis_qc(self.chain_id)
     }
 
     pub fn quorum(validator_set_power: TotalPower) -> TotalPower {

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,7 +13,7 @@ use sha2::Digest;
 use std::{
     collections::{hash_map, hash_set, HashMap, HashSet},
     hash::Hash,
-    slice, time::{Duration, Instant},
+    slice,
 };
 
 pub use ed25519_dalek::{SigningKey, VerifyingKey, Signature};
@@ -563,28 +563,5 @@ impl NewViewCollector {
         }
 
         self.accumulated_power >= QuorumCertificate::quorum(self.total_power)
-    }
-}
-
-pub struct SyncTriggerTimer {
-    last_update: Instant,
-    sync_trigger_timeout: Duration,
-}
-
-impl SyncTriggerTimer {
-
-    pub(crate) fn new(sync_trigger_timeout: Duration) -> SyncTriggerTimer {
-        Self {
-            last_update: Instant::now(),
-            sync_trigger_timeout
-        }
-    }
-
-    pub(crate) fn update(&mut self) {
-        self.last_update = Instant::now()
-    }
-
-    pub(crate) fn timeout(&self) -> bool {
-        Instant::now() - self.last_update >= self.sync_trigger_timeout
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,19 +5,20 @@
 
 //! Definitions for 'inert' types, i.e., those that are sent around and inspected, but have no active behavior.
 
-use crate::messages::Vote;
-use borsh::{BorshDeserialize, BorshSerialize};
-use ed25519_dalek::{Verifier, ed25519::Error};
-use rand::seq::SliceRandom;
-use sha2::Digest;
 use std::{
     collections::{hash_map, hash_set, HashMap, HashSet},
     hash::Hash,
     slice,
 };
 
+use borsh::{BorshDeserialize, BorshSerialize};
+use ed25519_dalek::{Verifier, ed25519::Error};
+use rand::seq::SliceRandom;
+use sha2::Digest;
 pub use ed25519_dalek::{SigningKey, VerifyingKey, Signature};
 pub use sha2::Sha256 as CryptoHasher;
+
+use crate::messages::Vote;
 
 pub type ChainID = u64;
 pub type BlockHeight = u64;
@@ -209,7 +210,7 @@ impl TryFrom<ValidatorSetUpdatesBytes> for ValidatorSetUpdates {
         let mut new_inserts = <HashMap<VerifyingKey, Power>> :: new();
         let convert_and_insert_inserts = |(k, v): (&[u8; 32], &u64)| -> Result<(), Error> {
             let pk = VerifyingKey::from_bytes(k)?;
-            new_inserts.insert(pk, *v); //insert should always return None
+            new_inserts.insert(pk, *v); // Safety: Insert should always return None.
             Ok(())
         };
         let _ = value.inserts.keys().zip(value.inserts.values()).try_for_each(convert_and_insert_inserts);
@@ -217,7 +218,7 @@ impl TryFrom<ValidatorSetUpdatesBytes> for ValidatorSetUpdates {
         let mut new_deletes: HashSet<VerifyingKey> = HashSet::new();
         let convert_and_insert_deletes = |k: &[u8; 32]| -> Result<(), Error> {
             let pk = VerifyingKey::from_bytes(k)?;
-            new_deletes.insert(pk); //insert should never return false
+            new_deletes.insert(pk); // Safety: Insert should never return false.
             Ok(())
         };
         let _ = value.deletes.iter().try_for_each(convert_and_insert_deletes);
@@ -234,10 +235,10 @@ impl Into<ValidatorSetUpdatesBytes> for &ValidatorSetUpdates {
     fn into(self) -> ValidatorSetUpdatesBytes {
         let mut new_inserts = <HashMap<VerifyingKeyBytes, Power>> :: new();
         self.inserts.keys().zip(self.inserts.values())
-        .for_each(|(k,v)| match new_inserts.insert(k.to_bytes(), *v) {_ => ()}); //insert should always return None
+        .for_each(|(k,v)| match new_inserts.insert(k.to_bytes(), *v) {_ => ()}); //Safety: Insert should always return None.
 
         let mut new_deletes: HashSet<VerifyingKeyBytes> = HashSet::new();
-        self.deletes.iter().for_each(|k| match new_deletes.insert(k.to_bytes()) {_ => ()}); //insert should never return false
+        self.deletes.iter().for_each(|k| match new_deletes.insert(k.to_bytes()) {_ => ()}); //Safety: Insert should never return false.
 
         ValidatorSetUpdatesBytes {
             inserts: new_inserts,
@@ -436,7 +437,7 @@ impl Into<ValidatorSetBytes> for &ValidatorSet {
 
         let mut new_powers = <HashMap<VerifyingKeyBytes, Power>> :: new();
         self.powers.keys().zip(self.powers.values())
-        .for_each(|(k,v)| match new_powers.insert(k.to_bytes(), *v) {_ => ()}); //insert should always return None
+        .for_each(|(k,v)| match new_powers.insert(k.to_bytes(), *v) {_ => ()}); // Safety: Insert should always return None
 
         ValidatorSetBytes {
             validators: new_validators,

--- a/src/types.rs
+++ b/src/types.rs
@@ -199,7 +199,7 @@ impl Phase {
 pub type AppStateUpdates = UpdateSet<Vec<u8>, Vec<u8>>;
 pub type ValidatorSetUpdates = UpdateSet<VerifyingKey, Power>;
 
-//internal representation of ValidatorSetUpdates
+/// Intermediate representation of [ValidatorSetUpdates] for safe serialization and deserialization.
 pub(crate) type ValidatorSetUpdatesBytes = UpdateSet<VerifyingKeyBytes, Power>;
 
 impl TryFrom<ValidatorSetUpdatesBytes> for ValidatorSetUpdates {
@@ -294,8 +294,8 @@ where
 
 /// Identities of validators and their voting powers.
 ///
-/// The validator set maintains the list of validators in ascending order of their verifying keys (public keys), and avails methods:
-/// [ValidatorSet::validators] and [Validators::validators_and_powers] to get them in this order.
+/// The validator set maintains the list of validators in ascending order of their [public keys](VerifyingKey), and avails methods:
+/// [ValidatorSet::validators] and [ValidatorSet::validators_and_powers] to get them in this order.
 /// 
 /// # Limits to total power
 /// 
@@ -400,7 +400,7 @@ impl ValidatorSet {
     }
 }
 
-// internal representation of ValidatorSet
+/// Intermediate representation of [ValidatorSet] for safe serialization and deserialization.
 #[derive(Clone, BorshSerialize, BorshDeserialize)]
 pub(crate) struct ValidatorSetBytes {
     // The verifying keys of validators are included here in ascending order.
@@ -445,8 +445,8 @@ impl Into<ValidatorSetBytes> for &ValidatorSet {
     }
 }
 
-/// Helps leaders incrementally form QuorumCertificates by combining votes for the same chain_id, view, block, and phase by replicas
-/// in a given validator set.
+/// Helps leaders incrementally form [QuorumCertificate]s by combining votes for the same chain_id, view, block, and phase by replicas
+/// in a given [validator set](ValidatorSet).
 pub(crate) struct VoteCollector {
     chain_id: ChainID,
     view: ViewNumber,

--- a/src/types.rs
+++ b/src/types.rs
@@ -136,9 +136,9 @@ impl QuorumCertificate {
         }
     }
 
-    pub const fn genesis_qc(chain_id: ChainID) -> QuorumCertificate {
+    pub const fn genesis_qc() -> QuorumCertificate {
         QuorumCertificate {
-            chain_id: chain_id,
+            chain_id: 0,
             view: 0,
             block: [0u8; 32],
             phase: Phase::Generic,
@@ -147,7 +147,7 @@ impl QuorumCertificate {
     }
 
     pub fn is_genesis_qc(&self) -> bool {
-        *self == Self::genesis_qc(self.chain_id)
+        *self == Self::genesis_qc()
     }
 
     pub fn quorum(validator_set_power: TotalPower) -> TotalPower {

--- a/src/types.rs
+++ b/src/types.rs
@@ -321,17 +321,10 @@ impl ValidatorSet {
         }
     }
 
-    fn validators_in_bytes(&self) -> Vec<PublicKeyBytes> {
-        self.validators
-        .iter()
-        .map(|pk| pk.to_bytes())
-        .collect()
-    }
-
     pub fn put(&mut self, validator: &PublicKey, power: Power) {
         if !self.powers.contains_key(validator) {
             let validator_bytes = validator.to_bytes();
-            let insert_pos = self.validators_in_bytes().binary_search(&validator_bytes).unwrap_err(); // ensures that self.validators are sorted
+            let insert_pos = self.validators.binary_search_by(|v| v.to_bytes().cmp(&validator_bytes)).unwrap_err();
             self.validators.insert(insert_pos, *validator);
         }
 
@@ -365,7 +358,8 @@ impl ValidatorSet {
     }
 
     pub fn remove(&mut self, validator: &PublicKey) -> Option<(PublicKey, Power)> {
-        if let Ok(pos) = self.validators_in_bytes().binary_search(&validator.to_bytes()) {
+        let validator_bytes = validator.to_bytes();
+        if let Ok(pos) = self.validators.binary_search_by(|v| v.to_bytes().cmp(&validator_bytes)) {
             self.validators.remove(pos);
             self.powers.remove_entry(validator)
         } else {
@@ -394,7 +388,8 @@ impl ValidatorSet {
     }
 
     pub fn position(&self, validator: &PublicKey) -> Option<usize> {
-        match self.validators_in_bytes().binary_search(&validator.to_bytes()) {
+        let validator_bytes = validator.to_bytes();
+        match self.validators.binary_search_by(|v| v.to_bytes().cmp(&validator_bytes)) {
             Ok(pos) => Some(pos),
             Err(_) => None,
         }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -465,7 +465,7 @@ impl Node {
     ) -> Node {
         let kv_store = MemDB::new();
 
-        Replica::initialize(kv_store.clone(), init_as, init_vs);
+        Replica::initialize(kv_store.clone(), init_as, init_vs, 0);
 
         let verifying_key = keypair.verifying_key().to_bytes();
         let tx_queue = Arc::new(Mutex::new(Vec::new()));

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -465,7 +465,7 @@ impl Node {
     ) -> Node {
         let kv_store = MemDB::new();
 
-        Replica::initialize(kv_store.clone(), init_as, init_vs, 0);
+        Replica::initialize(kv_store.clone(), init_as, init_vs);
 
         let verifying_key = keypair.verifying_key().to_bytes();
         let tx_queue = Arc::new(Mutex::new(Vec::new()));

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -477,7 +477,6 @@ impl Node {
             .me(keypair)
             .chain_id(0)
             .sync_request_limit(10)
-            .sync_trigger_timeout(Duration::new(40, 0))
             .sync_response_timeout(Duration::new(3, 0))
             .progress_msg_buffer_capacity(10000)
             .log_events(true)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -476,7 +476,7 @@ impl Node {
             me: keypair,
             chain_id: 0,
             sync_request_limit: 10,
-            sync_trigger_timeout: Duration::new(10, 0),
+            sync_trigger_timeout: Duration::new(40, 0),
             sync_response_timeout: Duration::new(3, 0),
             progress_msg_buffer_capacity: 10000,
             log_events: true,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -29,7 +29,7 @@ use hotstuff_rs::events::InsertBlockEvent;
 use hotstuff_rs::messages::*;
 use hotstuff_rs::networking::Network;
 use hotstuff_rs::pacemaker::DefaultPacemaker;
-use hotstuff_rs::replica::{Replica, ReplicaBuilder, Configuration};
+use hotstuff_rs::replica::{Replica, ReplicaSpec, Configuration};
 use hotstuff_rs::state::{KVGet, KVStore, WriteBatch};
 use hotstuff_rs::types::{
     AppStateUpdates, CryptoHash, Power, PublicKey, ValidatorSet, ValidatorSetUpdates,
@@ -472,22 +472,23 @@ impl Node {
         let pacemaker =
             DefaultPacemaker::new(Duration::from_millis(500));
 
-        let configuration = Configuration {
-            me: keypair,
-            chain_id: 0,
-            sync_request_limit: 10,
-            sync_trigger_timeout: Duration::new(40, 0),
-            sync_response_timeout: Duration::new(3, 0),
-            progress_msg_buffer_capacity: 10000,
-            log_events: true,
-        };
+        let configuration = 
+            Configuration :: builder()
+            .me(keypair)
+            .chain_id(0)
+            .sync_request_limit(10)
+            .sync_trigger_timeout(Duration::new(40, 0))
+            .sync_response_timeout(Duration::new(3, 0))
+            .progress_msg_buffer_capacity(10000)
+            .log_events(true)
+            .build();
 
         let insert_block_handler = |insert_block_event: &InsertBlockEvent| {
             println!("Inserted block with hash: {:?}, timestamp: {:?}", insert_block_event.block.hash, insert_block_event.timestamp)
         };
 
         let replica = 
-            ReplicaBuilder :: builder()
+            ReplicaSpec :: builder()
             .app(NumberApp::new(tx_queue.clone()))
             .pacemaker(pacemaker)
             .network(network)

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -469,14 +469,14 @@ impl Node {
         let public_key = keypair.verifying_key().to_bytes();
         let tx_queue = Arc::new(Mutex::new(Vec::new()));
         let pacemaker =
-            DefaultPacemaker::new(Duration::from_millis(500), 10, Duration::from_secs(3));
+            DefaultPacemaker::new(Duration::from_millis(500));
 
         let configuration = Configuration {
             me: keypair,
-            sync_request_limit: 500,
+            sync_request_limit: 10,
             sync_trigger_timeout: Duration::new(10, 0),
-            sync_response_timeout: Duration::new(10, 0),
-            progress_msg_buffer_capacity: 1000,
+            sync_response_timeout: Duration::new(3, 0),
+            progress_msg_buffer_capacity: 10000,
             log_events: true,
         };
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -32,7 +32,7 @@ use hotstuff_rs::pacemaker::DefaultPacemaker;
 use hotstuff_rs::replica::{Replica, ReplicaBuilder, Configuration};
 use hotstuff_rs::state::{KVGet, KVStore, WriteBatch};
 use hotstuff_rs::types::{
-    AppStateUpdates, ChainID, CryptoHash, Power, PublicKey, ValidatorSet, ValidatorSetUpdates,
+    AppStateUpdates, CryptoHash, Power, PublicKey, ValidatorSet, ValidatorSetUpdates,
     ViewNumber,
 };
 use log::LevelFilter;
@@ -337,9 +337,6 @@ enum NumberAppTransaction {
 }
 
 impl App<MemDB> for NumberApp {
-    fn chain_id(&self) -> ChainID {
-        0
-    }
 
     fn produce_block(&mut self, request: ProduceBlockRequest<MemDB>) -> ProduceBlockResponse {
         thread::sleep(Duration::from_millis(250));
@@ -407,6 +404,10 @@ impl App<MemDB> for NumberApp {
             }
         }
     }
+
+    fn validate_block_for_sync(&mut self, request: ValidateBlockRequest<MemDB>) -> ValidateBlockResponse {
+        self.validate_block(request)
+    }
 }
 
 impl NumberApp {
@@ -473,6 +474,7 @@ impl Node {
 
         let configuration = Configuration {
             me: keypair,
+            chain_id: 0,
             sync_request_limit: 10,
             sync_trigger_timeout: Duration::new(10, 0),
             sync_response_timeout: Duration::new(3, 0),

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -494,7 +494,7 @@ impl Node {
             .network(network)
             .kv_store(kv_store)
             .configuration(configuration)
-            .on_insert_block(Box::new(insert_block_handler))
+            .on_insert_block(insert_block_handler)
             .build()
             .start();
 


### PR DESCRIPTION
This commit includes the following:
1. Upgrade to `ed25519-dalek` version 2.0.0 and related shift from exposing `PublicKeyBytes` as validator identifiers to using `PublicKey` (`ed25519-dalek::VerifyingKey`) instead
2. A non-stack-overflowing version of `commit_block` (in response to [Issue #2](https://github.com/parallelchain-io/hotstuff_rs/issues/2))
3. Fixed `pending_validator_set_updates` [(Issue #15)](https://github.com/parallelchain-io/hotstuff_rs/issues/15)
4. Minor bug fix in `logging.rs`, the bug appearing due to `PublicKeyBytes` and `CryptoHash` being type aliases for the same type

Comment on (2):
The previous version of `commit_block` was non-tail-recursive, which means potential stack overflow as more and more stack frames are added and there is nothing the compiler can do about it. In some other languages, implementing a tail-recursive version instead would avoid the stack overflow problem and be optimised by the compiler to performance equivalent to that of a loop (Tail Call Optimisation). However, Rust does not implement Tail Call Optimisations,. Moreover, it has iterators (and closures) which are marginally faster than loops, and folding over an iterator is logically equivalent to tail-recursion. Hence, my solution involves folding over an iterator with a closure that updates the state thereby committing a corresponding block, from oldest blocks to newest blocks. 
