### PR TITLE
Event Handling and Logging

### DIFF
--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -343,6 +343,7 @@ fn on_receive_proposal<K: KVStore, N: Network>(
             &proposal.block,
             app_state_updates.as_ref(),
             validator_set_updates.as_ref(),
+            event_publisher,
         );
         if let Some(updates) = validator_set_updates_because_of_commit {
             pm_stub.update_validator_set(updates);
@@ -670,6 +671,7 @@ fn sync_with<K: KVStore, N: Network>(
                             &block,
                             app_state_updates.as_ref(),
                             validator_set_updates.as_ref(),
+                            event_publisher,
                         );
 
                         if let Some(updates) = validator_set_updates_because_of_commit {

--- a/src/event_bus.rs
+++ b/src/event_bus.rs
@@ -1,0 +1,101 @@
+use crate::events::*;
+use std::sync::mpsc::Receiver;
+use std::sync::mpsc::TryRecvError;
+use std::thread;
+use std::thread::JoinHandle;
+
+pub(crate) type HandlerPtr<T> = Box<dyn Fn(&T) + Send>;
+
+pub(crate) struct EventHandlers {
+    pub(crate) insert_block_handlers: Vec<HandlerPtr<InsertBlockEvent>>,
+    pub(crate) commit_block_handlers: Vec<HandlerPtr<CommitBlockEvent>>,
+    pub(crate) prune_block_handlers: Vec<HandlerPtr<PruneBlockEvent>>,
+    pub(crate) propose_handlers: Vec<HandlerPtr<ProposeEvent>>,
+    pub(crate) receive_proposal_handlers: Vec<HandlerPtr<ReceiveProposalEvent>>,
+    pub(crate) nudge_handlers: Vec<HandlerPtr<NudgeEvent>>,
+    pub(crate) receive_nudge_handlers: Vec<HandlerPtr<ReceiveNudgeEvent>>,
+    pub(crate) vote_handlers: Vec<HandlerPtr<VoteEvent>>,
+    pub(crate) receive_vote_handlers: Vec<HandlerPtr<ReceiveVoteEvent>>,
+    pub(crate) new_view_handlers: Vec<HandlerPtr<NewViewEvent>>,
+    pub(crate) receive_new_view_handlers: Vec<HandlerPtr<ReceiveNewViewEvent>>,
+    pub(crate) start_view_handlers: Vec<HandlerPtr<StartViewEvent>>,
+    pub(crate) view_timeout_handlers: Vec<HandlerPtr<ViewTimeoutEvent>>,
+    pub(crate) start_sync_handlers: Vec<HandlerPtr<StartSyncEvent>>,
+    pub(crate) end_sync_handlers: Vec<HandlerPtr<EndSyncEvent>>,
+}
+
+impl EventHandlers {
+
+    pub fn fire_handlers(&self, event: Event) {
+        match event {
+            Event::InsertBlock(insert_block_event) => 
+                self.insert_block_handlers.iter().for_each(|handler| handler(&insert_block_event)),
+
+            Event::CommitBlock(commit_block_event) => 
+                self.commit_block_handlers.iter().for_each(|handler| handler(&commit_block_event)),
+
+            Event::PruneBlock(prune_block_event) => 
+                self.prune_block_handlers.iter().for_each(|handler| handler(&prune_block_event)),
+
+            Event::Propose(propose_event) => 
+                self.propose_handlers.iter().for_each(|handler| handler(&propose_event)),
+
+            Event::ReceiveProposal(receive_proposal_event) => 
+                self.receive_proposal_handlers.iter().for_each(|handler| handler(&receive_proposal_event)),
+
+            Event::Nudge(nudge_event) => 
+                self.nudge_handlers.iter().for_each(|handler| handler(&nudge_event)),
+
+            Event::ReceiveNudge(receive_nudge_event) => 
+                self.receive_nudge_handlers.iter().for_each(|handler| handler(&receive_nudge_event)),
+
+            Event::Vote(vote_event) => 
+                self.vote_handlers.iter().for_each(|handler| handler(&vote_event)),
+
+            Event::ReceiveVote(receive_vote_event) => 
+                self.receive_vote_handlers.iter().for_each(|handler| handler(&receive_vote_event)),
+
+            Event::NewView(new_view_event) => 
+                self.new_view_handlers.iter().for_each(|handler| handler(&new_view_event)),
+
+            Event::ReceiveNewView(receive_new_view) => 
+                self.receive_new_view_handlers.iter().for_each(|handler| handler(&receive_new_view)),
+
+            Event::StartView(start_view_event) => 
+                self.start_view_handlers.iter().for_each(|handler| handler(&start_view_event)),
+
+            Event::ViewTimeout(view_timeout_event) => 
+                self.view_timeout_handlers.iter().for_each(|handler| handler(&view_timeout_event)),
+
+            Event::StartSync(start_sync_event) => 
+                self.start_sync_handlers.iter().for_each(|handler| handler(&start_sync_event)),
+
+            Event::EndSync(end_sync_event) => 
+                self.end_sync_handlers.iter().for_each(|handler| handler(&end_sync_event)),
+        }
+    }
+}
+
+
+pub(crate) fn start_event_bus(
+    event_handlers: EventHandlers,
+    event_subscriber: Receiver<Event>,
+    shutdown_signal: Receiver<()>, 
+) -> JoinHandle<()> {
+    thread::spawn(move || loop {
+        match shutdown_signal.try_recv() {
+            Ok(()) => return,
+            Err(TryRecvError::Empty) => (),
+            Err(TryRecvError::Disconnected) => {
+                panic!("event_bus thread disconnected from main thread")
+            }
+        }
+
+        if let Ok(event) = event_subscriber.try_recv() {
+            (&event_handlers).fire_handlers(event)
+        } else if let Err(TryRecvError::Disconnected) = event_subscriber.try_recv()  {
+            panic!("The algorithm thread (event publisher) was disconnected from the channel")
+        }
+
+    })
+}

--- a/src/event_bus.rs
+++ b/src/event_bus.rs
@@ -1,4 +1,6 @@
 use crate::events::*;
+use crate::logging;
+use crate::logging::Logger;
 use std::sync::mpsc::Receiver;
 use std::sync::mpsc::TryRecvError;
 use std::thread;
@@ -10,23 +12,88 @@ pub(crate) struct EventHandlers {
     pub(crate) insert_block_handlers: Vec<HandlerPtr<InsertBlockEvent>>,
     pub(crate) commit_block_handlers: Vec<HandlerPtr<CommitBlockEvent>>,
     pub(crate) prune_block_handlers: Vec<HandlerPtr<PruneBlockEvent>>,
+    pub(crate) update_highest_qc_handlers: Vec<HandlerPtr<UpdateHighestQCEvent>>,
+    pub(crate) update_locked_view_handlers: Vec<HandlerPtr<UpdateLockedViewEvent>>,
+    pub(crate) update_validator_set_handlers: Vec<HandlerPtr<UpdateValidatorSetEvent>>,
+
     pub(crate) propose_handlers: Vec<HandlerPtr<ProposeEvent>>,
-    pub(crate) receive_proposal_handlers: Vec<HandlerPtr<ReceiveProposalEvent>>,
     pub(crate) nudge_handlers: Vec<HandlerPtr<NudgeEvent>>,
-    pub(crate) receive_nudge_handlers: Vec<HandlerPtr<ReceiveNudgeEvent>>,
     pub(crate) vote_handlers: Vec<HandlerPtr<VoteEvent>>,
-    pub(crate) receive_vote_handlers: Vec<HandlerPtr<ReceiveVoteEvent>>,
     pub(crate) new_view_handlers: Vec<HandlerPtr<NewViewEvent>>,
+
+    pub(crate) receive_proposal_handlers: Vec<HandlerPtr<ReceiveProposalEvent>>,
+    pub(crate) receive_nudge_handlers: Vec<HandlerPtr<ReceiveNudgeEvent>>,
+    pub(crate) receive_vote_handlers: Vec<HandlerPtr<ReceiveVoteEvent>>,
     pub(crate) receive_new_view_handlers: Vec<HandlerPtr<ReceiveNewViewEvent>>,
+
     pub(crate) start_view_handlers: Vec<HandlerPtr<StartViewEvent>>,
     pub(crate) view_timeout_handlers: Vec<HandlerPtr<ViewTimeoutEvent>>,
+    pub(crate) collect_qc_handlers: Vec<HandlerPtr<CollectQCEvent>>,
+
     pub(crate) start_sync_handlers: Vec<HandlerPtr<StartSyncEvent>>,
     pub(crate) end_sync_handlers: Vec<HandlerPtr<EndSyncEvent>>,
+    pub(crate) receive_sync_request_handlers: Vec<HandlerPtr<ReceiveSyncRequestEvent>>,
+    pub(crate) send_sync_response_handlers: Vec<HandlerPtr<SendSyncResponseEvent>>,
 }
 
 impl EventHandlers {
 
-    pub fn fire_handlers(&self, event: Event) {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.insert_block_handlers.is_empty()
+        && self.commit_block_handlers.is_empty()
+        && self.prune_block_handlers.is_empty()
+        && self.update_highest_qc_handlers.is_empty()
+        && self.update_locked_view_handlers.is_empty()
+        && self.update_validator_set_handlers.is_empty()
+        && self.propose_handlers.is_empty()
+        && self.nudge_handlers.is_empty()
+        && self.vote_handlers.is_empty()
+        && self.new_view_handlers.is_empty()
+        && self.receive_proposal_handlers.is_empty()
+        && self.receive_nudge_handlers.is_empty()
+        && self.receive_vote_handlers.is_empty()
+        && self.receive_new_view_handlers.is_empty()
+        && self.start_view_handlers.is_empty()
+        && self.view_timeout_handlers.is_empty()
+        && self.collect_qc_handlers.is_empty()
+        && self.start_sync_handlers.is_empty()
+        && self.end_sync_handlers.is_empty()
+        && self.receive_sync_request_handlers.is_empty()
+        && self.send_sync_response_handlers.is_empty()
+    }
+
+    pub(crate) fn add_logging_handlers(&mut self) {
+
+        self.insert_block_handlers.push(logging::InsertBlockEvent::get_logger());
+        self.commit_block_handlers.push(logging::CommitBlockEvent::get_logger());
+        self.prune_block_handlers.push(logging::PruneBlockEvent::get_logger());
+        self.update_highest_qc_handlers.push(logging::UpdateHighestQCEvent::get_logger());
+        self.update_locked_view_handlers.push(logging::UpdateLockedViewEvent::get_logger());
+        self.update_validator_set_handlers.push(logging::UpdateValidatorSetEvent::get_logger());
+
+        self.propose_handlers.push(logging::ProposeEvent::get_logger());
+        self.nudge_handlers.push(logging::NudgeEvent::get_logger());
+        self.vote_handlers.push(logging::VoteEvent::get_logger());
+        self.new_view_handlers.push(logging::NewViewEvent::get_logger());
+
+        self.receive_proposal_handlers.push(logging::ReceiveProposalEvent::get_logger());
+        self.receive_nudge_handlers.push(logging::ReceiveNudgeEvent::get_logger());
+        self.receive_vote_handlers.push(logging::ReceiveVoteEvent::get_logger());
+        self.receive_new_view_handlers.push(logging::ReceiveNewViewEvent::get_logger());
+
+        self.start_view_handlers.push(logging::StartViewEvent::get_logger());
+        self.view_timeout_handlers.push(logging::ViewTimeoutEvent::get_logger());
+        self.collect_qc_handlers.push(logging::CollectQCEvent::get_logger());
+
+        self.start_sync_handlers.push(logging::StartSyncEvent::get_logger());
+        self.end_sync_handlers.push(logging::EndSyncEvent::get_logger());
+        self.receive_sync_request_handlers.push(logging::ReceiveSyncRequestEvent::get_logger());
+        self.send_sync_response_handlers.push(logging::SendSyncResponseEvent::get_logger());
+
+    }
+
+    pub(crate) fn fire_handlers(&self, event: Event) {
+
         match event {
             Event::InsertBlock(insert_block_event) => 
                 self.insert_block_handlers.iter().for_each(|handler| handler(&insert_block_event)),
@@ -37,26 +104,35 @@ impl EventHandlers {
             Event::PruneBlock(prune_block_event) => 
                 self.prune_block_handlers.iter().for_each(|handler| handler(&prune_block_event)),
 
+            Event::UpdateHighestQC(update_highest_qc_event) =>
+                self.update_highest_qc_handlers.iter().for_each(|handler| handler(&update_highest_qc_event)),
+
+            Event::UpdateLockedView(update_locked_view_event) =>
+                self.update_locked_view_handlers.iter().for_each(|handler| handler(&update_locked_view_event)),
+
+            Event::UpdateValidatorSet(update_validator_set_event) =>
+                self.update_validator_set_handlers.iter().for_each(|handler| handler(&update_validator_set_event)),
+
             Event::Propose(propose_event) => 
                 self.propose_handlers.iter().for_each(|handler| handler(&propose_event)),
-
-            Event::ReceiveProposal(receive_proposal_event) => 
-                self.receive_proposal_handlers.iter().for_each(|handler| handler(&receive_proposal_event)),
 
             Event::Nudge(nudge_event) => 
                 self.nudge_handlers.iter().for_each(|handler| handler(&nudge_event)),
 
-            Event::ReceiveNudge(receive_nudge_event) => 
-                self.receive_nudge_handlers.iter().for_each(|handler| handler(&receive_nudge_event)),
-
             Event::Vote(vote_event) => 
                 self.vote_handlers.iter().for_each(|handler| handler(&vote_event)),
 
-            Event::ReceiveVote(receive_vote_event) => 
-                self.receive_vote_handlers.iter().for_each(|handler| handler(&receive_vote_event)),
-
             Event::NewView(new_view_event) => 
                 self.new_view_handlers.iter().for_each(|handler| handler(&new_view_event)),
+
+            Event::ReceiveProposal(receive_proposal_event) => 
+                self.receive_proposal_handlers.iter().for_each(|handler| handler(&receive_proposal_event)),
+
+            Event::ReceiveNudge(receive_nudge_event) => 
+                self.receive_nudge_handlers.iter().for_each(|handler| handler(&receive_nudge_event)),
+
+            Event::ReceiveVote(receive_vote_event) => 
+                self.receive_vote_handlers.iter().for_each(|handler| handler(&receive_vote_event)),
 
             Event::ReceiveNewView(receive_new_view) => 
                 self.receive_new_view_handlers.iter().for_each(|handler| handler(&receive_new_view)),
@@ -67,11 +143,20 @@ impl EventHandlers {
             Event::ViewTimeout(view_timeout_event) => 
                 self.view_timeout_handlers.iter().for_each(|handler| handler(&view_timeout_event)),
 
+            Event::CollectQC(collect_qc_event) =>
+                self.collect_qc_handlers.iter().for_each(|handler| handler(&collect_qc_event)),
+
             Event::StartSync(start_sync_event) => 
                 self.start_sync_handlers.iter().for_each(|handler| handler(&start_sync_event)),
 
             Event::EndSync(end_sync_event) => 
                 self.end_sync_handlers.iter().for_each(|handler| handler(&end_sync_event)),
+
+            Event::ReceiveSyncRequest(receive_sync_request_event) =>
+                self.receive_sync_request_handlers.iter().for_each(|handler| handler(&receive_sync_request_event)),
+
+            Event::SendSyncResponse(send_sync_response_event) =>
+                self.send_sync_response_handlers.iter().for_each(|handler| handler(&send_sync_response_event)),
         }
     }
 }
@@ -94,7 +179,7 @@ pub(crate) fn start_event_bus(
         if let Ok(event) = event_subscriber.try_recv() {
             (&event_handlers).fire_handlers(event)
         } else if let Err(TryRecvError::Disconnected) = event_subscriber.try_recv()  {
-            panic!("The algorithm thread (event publisher) was disconnected from the channel")
+            panic!("The algorithm thread (event publisher) disconnected from the channel")
         }
 
     })

--- a/src/event_bus.rs
+++ b/src/event_bus.rs
@@ -1,8 +1,18 @@
+//! Event bus thread for handling events published from the algorithm and sync_server threads
+//! 
+//! When the thread receives a message containing an event, it fires all handlers for the event
+//! stored in EventHandlers
+//! 
+//! When no handlers are stored in a replica's instance of EventHandlers then this thread is not started
+//! 
+//! A replica's instance of EventHandlers contains the handlers provided upon building the replica,
+//! and if logging is enabled via replica's config its instance of EventHandlers also contains
+//! the default logging handlers defined in logging.rs
+
 use crate::events::*;
 use crate::logging;
 use crate::logging::Logger;
-use std::sync::mpsc::Receiver;
-use std::sync::mpsc::TryRecvError;
+use std::sync::mpsc::{Receiver, TryRecvError};
 use std::thread;
 use std::thread::JoinHandle;
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,102 @@
+use std::time::{SystemTime, Duration};
+
+use crate::{types::*, messages::{Proposal, Nudge, Vote, NewView}};
+
+pub enum Event {
+    InsertBlock(InsertBlockEvent),
+    CommitBlock(CommitBlockEvent),
+    PruneBlock(PruneBlockEvent),
+    Propose(ProposeEvent),
+    ReceiveProposal(ReceiveProposalEvent),
+    Nudge(NudgeEvent),
+    ReceiveNudge(ReceiveNudgeEvent),
+    Vote(VoteEvent),
+    ReceiveVote(ReceiveVoteEvent),
+    NewView(NewViewEvent),
+    ReceiveNewView(ReceiveNewViewEvent),
+    StartView(StartViewEvent),
+    ViewTimeout(ViewTimeoutEvent),
+    StartSync(StartSyncEvent),
+    EndSync(EndSyncEvent),
+}
+
+pub struct InsertBlockEvent {
+    pub timestamp: SystemTime, 
+    pub block: Block,
+}
+
+pub struct CommitBlockEvent {
+    pub timestamp: SystemTime,
+    pub block: Block,
+}
+
+pub struct PruneBlockEvent {
+    pub timestamp: SystemTime,
+    pub block: Block,
+}
+
+pub struct ProposeEvent {
+    pub timestamp: SystemTime,
+    pub proposal: Proposal,
+}
+
+pub struct ReceiveProposalEvent {
+    pub timestamp: SystemTime,
+    pub origin: PublicKey,
+    pub proposal: Proposal,
+}
+
+pub struct NudgeEvent {
+    pub timestamp: SystemTime,
+    pub nudge: Nudge,
+}
+
+pub struct ReceiveNudgeEvent {
+    pub timestamp: SystemTime,
+    pub origin: PublicKey,
+    pub nudge: Nudge,
+}
+
+pub struct VoteEvent {
+    pub timestamp: SystemTime,
+    pub vote: Vote,
+}
+
+pub struct ReceiveVoteEvent {
+    pub timestamp: SystemTime,
+    pub origin: PublicKey,
+    pub vote: Vote,
+}
+
+pub struct NewViewEvent {
+    pub timestamp: SystemTime,
+    pub new_view: NewView,
+}
+
+pub struct ReceiveNewViewEvent {
+    pub timestamp: SystemTime,
+    pub origin: PublicKey,
+    pub new_view: NewView,
+}
+
+pub struct StartViewEvent {
+    pub timestamp: SystemTime,
+    pub view: ViewNumber,
+}
+
+pub struct ViewTimeoutEvent {
+    pub timestamp: SystemTime,
+    pub view: ViewNumber,
+    pub timeout: Duration,
+}
+
+pub struct StartSyncEvent {
+    pub timestamp: SystemTime,
+    pub peer: PublicKey,
+}
+
+pub struct EndSyncEvent {
+    pub timestamp: SystemTime,
+    pub peer: PublicKey,
+    pub blocks_synced: u64,
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,9 +1,10 @@
 //! Definitions of hotstuff-rs events for event handling and logging
 //! Note: an event for a given action indicates that the action has been completed
 
-use std::{time::{SystemTime, Duration}, sync::mpsc::Sender};
-
-use crate::{types::*, messages::{Proposal, Nudge, Vote, NewView}};
+use crate::types::{Block, QuorumCertificate, CryptoHash, ViewNumber, ValidatorSetUpdates, PublicKey};
+use crate::messages::{Proposal, Nudge, Vote, NewView};
+use std::time::{SystemTime, Duration};
+use std::sync::mpsc::Sender;
 
 pub enum Event {
     // Events that change persistent state.

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,23 +1,45 @@
-use std::time::{SystemTime, Duration};
+//! Definitions of hotstuff-rs events for event handling and logging
+//! Note: an event for a given action indicates that the action has been completed
+
+use std::{time::{SystemTime, Duration}, sync::mpsc::Sender};
 
 use crate::{types::*, messages::{Proposal, Nudge, Vote, NewView}};
 
 pub enum Event {
+    // Events that change persistent state.
     InsertBlock(InsertBlockEvent),
     CommitBlock(CommitBlockEvent),
     PruneBlock(PruneBlockEvent),
+    UpdateHighestQC(UpdateHighestQCEvent),
+    UpdateLockedView(UpdateLockedViewEvent),
+    UpdateValidatorSet(UpdateValidatorSetEvent),
+    // Events that involve broadcasting/sending a Progress Message.
     Propose(ProposeEvent),
-    ReceiveProposal(ReceiveProposalEvent),
     Nudge(NudgeEvent),
-    ReceiveNudge(ReceiveNudgeEvent),
     Vote(VoteEvent),
-    ReceiveVote(ReceiveVoteEvent),
     NewView(NewViewEvent),
+    // Events that involve receiving a Progress Message.
+    ReceiveProposal(ReceiveProposalEvent),
+    ReceiveNudge(ReceiveNudgeEvent),
+    ReceiveVote(ReceiveVoteEvent),
     ReceiveNewView(ReceiveNewViewEvent),
+    // Progress mode events.
     StartView(StartViewEvent),
     ViewTimeout(ViewTimeoutEvent),
+    CollectQC(CollectQCEvent),
+    // Sync mode events.
     StartSync(StartSyncEvent),
     EndSync(EndSyncEvent),
+    ReceiveSyncRequest(ReceiveSyncRequestEvent),
+    SendSyncResponse(SendSyncResponseEvent),
+}
+
+impl Event {
+    pub(crate) fn publish(event_publisher: &Option<Sender<Event>>, event: Event) {
+        if let Some(event_publisher) = event_publisher {
+            event_publisher.send(event).unwrap()
+        }
+    }
 }
 
 pub struct InsertBlockEvent {
@@ -27,22 +49,32 @@ pub struct InsertBlockEvent {
 
 pub struct CommitBlockEvent {
     pub timestamp: SystemTime,
-    pub block: Block,
+    pub block: CryptoHash,
 }
 
 pub struct PruneBlockEvent {
     pub timestamp: SystemTime,
-    pub block: Block,
+    pub block: CryptoHash,
+}
+
+pub struct UpdateHighestQCEvent {
+    pub timestamp: SystemTime,
+    pub highest_qc: QuorumCertificate,
+}
+
+pub struct UpdateLockedViewEvent {
+    pub timestamp: SystemTime,
+    pub locked_view: ViewNumber,
+}
+
+pub struct UpdateValidatorSetEvent {
+    pub timestamp: SystemTime,
+    pub cause_block: CryptoHash,
+    pub validator_set_updates: ValidatorSetUpdates,
 }
 
 pub struct ProposeEvent {
     pub timestamp: SystemTime,
-    pub proposal: Proposal,
-}
-
-pub struct ReceiveProposalEvent {
-    pub timestamp: SystemTime,
-    pub origin: PublicKey,
     pub proposal: Proposal,
 }
 
@@ -51,26 +83,32 @@ pub struct NudgeEvent {
     pub nudge: Nudge,
 }
 
-pub struct ReceiveNudgeEvent {
-    pub timestamp: SystemTime,
-    pub origin: PublicKey,
-    pub nudge: Nudge,
-}
-
 pub struct VoteEvent {
     pub timestamp: SystemTime,
-    pub vote: Vote,
-}
-
-pub struct ReceiveVoteEvent {
-    pub timestamp: SystemTime,
-    pub origin: PublicKey,
     pub vote: Vote,
 }
 
 pub struct NewViewEvent {
     pub timestamp: SystemTime,
     pub new_view: NewView,
+}
+
+pub struct ReceiveProposalEvent {
+    pub timestamp: SystemTime,
+    pub origin: PublicKey,
+    pub proposal: Proposal,
+}
+
+pub struct ReceiveNudgeEvent {
+    pub timestamp: SystemTime,
+    pub origin: PublicKey,
+    pub nudge: Nudge,
+}
+
+pub struct ReceiveVoteEvent {
+    pub timestamp: SystemTime,
+    pub origin: PublicKey,
+    pub vote: Vote,
 }
 
 pub struct ReceiveNewViewEvent {
@@ -81,6 +119,7 @@ pub struct ReceiveNewViewEvent {
 
 pub struct StartViewEvent {
     pub timestamp: SystemTime,
+    pub leader: PublicKey,
     pub view: ViewNumber,
 }
 
@@ -88,6 +127,11 @@ pub struct ViewTimeoutEvent {
     pub timestamp: SystemTime,
     pub view: ViewNumber,
     pub timeout: Duration,
+}
+
+pub struct CollectQCEvent {
+    pub timestamp: SystemTime,
+    pub quorum_certificate: QuorumCertificate,
 }
 
 pub struct StartSyncEvent {
@@ -99,4 +143,18 @@ pub struct EndSyncEvent {
     pub timestamp: SystemTime,
     pub peer: PublicKey,
     pub blocks_synced: u64,
+}
+
+pub struct ReceiveSyncRequestEvent {
+    pub timestamp: SystemTime,
+    pub peer: PublicKey,
+    pub start_height: u64,
+    pub limit: u32,
+}
+
+pub struct SendSyncResponseEvent {
+    pub timestamp: SystemTime,
+    pub peer: PublicKey,
+    pub blocks: Vec<Block>,
+    pub highest_qc: QuorumCertificate,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,3 +61,7 @@ pub mod networking;
 pub mod sync_server;
 
 pub mod replica;
+
+pub mod event_bus;
+
+pub mod events;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -24,7 +24,7 @@ pub const INSERT_BLOCK: &str = "InsertedBlock";
 pub const COMMIT_BLOCK: &str = "CommittedBlock";
 pub const PRUNE_BLOCK: &str = "PrunedBlock";
 pub const UPDATE_HIGHEST_QC: &str = "UpdatedHighestQC";
-pub const UPDATE_LOCKED_VIEW: &str = "UpdateLockedView";
+pub const UPDATE_LOCKED_VIEW: &str = "UpdatedLockedView";
 pub const UPDATE_VALIDATOR_SET: &str = "UpdatedValidatorSet";
 
 pub const PROPOSE: &str = "Proposed";
@@ -49,7 +49,13 @@ pub const SEND_SYNC_RESPONSE: &str = "SentSyncResponse";
 impl Logger for InsertBlockEvent {
     fn get_logger() -> Box<dyn Fn(&Self) + Send> {
         let logger = |insert_block_event: &InsertBlockEvent| {
-            log::debug!("{}, {:?}, {}, {}", INSERT_BLOCK, insert_block_event.timestamp, succinct(&insert_block_event.block.hash), insert_block_event.block.height)
+            log::debug!(
+                "{}, {:?}, {}, {}",
+                INSERT_BLOCK,
+                insert_block_event.timestamp,
+                succinct(&insert_block_event.block.hash),
+                insert_block_event.block.height
+            )
         };
         Box::new(logger)
     }
@@ -106,7 +112,12 @@ impl Logger for UpdateLockedViewEvent {
 impl Logger for UpdateValidatorSetEvent {
     fn get_logger() -> Box<dyn Fn(&Self) + Send> {
         let logger = |update_validator_set_event: &UpdateValidatorSetEvent| {
-            log::info!("{}, {:?}, {}", UPDATE_VALIDATOR_SET, update_validator_set_event.timestamp, succinct(&update_validator_set_event.cause_block))
+            log::info!(
+                "{}, {:?}, {}",
+                UPDATE_VALIDATOR_SET,
+                update_validator_set_event.timestamp,
+                succinct(&update_validator_set_event.cause_block)
+            )
         };
         Box::new(logger)
     }
@@ -115,7 +126,14 @@ impl Logger for UpdateValidatorSetEvent {
 impl Logger for ProposeEvent {
     fn get_logger() -> Box<dyn Fn(&Self) + Send> {
         let logger = |propose_event: &ProposeEvent| {
-            log::info!("{}, {:?}, {}, {}, {}", PROPOSE, propose_event.timestamp, succinct(&propose_event.proposal.block.hash), propose_event.proposal.block.height, propose_event.proposal.view)
+            log::info!(
+                "{}, {:?}, {}, {}, {}",
+                PROPOSE,
+                propose_event.timestamp,
+                succinct(&propose_event.proposal.block.hash),
+                propose_event.proposal.block.height,
+                propose_event.proposal.view
+            )
         };
         Box::new(logger)
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -50,7 +50,7 @@
 //! - **Highest View Entered** (initialized to 0).
 //! - **Highest Quorum Certificate** (initialized to [the genesis qc](QuorumCertificate::genesis_qc)).
 
-use crate::events::{Event, InsertBlockEvent, PruneBlockEvent, CommitBlockEvent, UpdateValidatorSetEvent, UpdateHighestQCEvent, UpdateLockedViewEvent};
+use crate::events::{Event, InsertBlockEvent, CommitBlockEvent, PruneBlockEvent, UpdateHighestQCEvent, UpdateLockedViewEvent, UpdateValidatorSetEvent};
 use crate::types::*;
 use borsh::{BorshDeserialize, BorshSerialize};
 use std::iter::successors;
@@ -147,6 +147,7 @@ impl<K: KVStore> BlockTree<K> {
     ) -> Option<ValidatorSetUpdates> {
         let mut wb = BlockTreeWriteBatch::new();
         let mut update_locked_view: Option<ViewNumber> = None;
+        let mut update_highest_qc: Option<QuorumCertificate> = None;
 
         // Insert block.
         wb.set_block(block);
@@ -165,25 +166,20 @@ impl<K: KVStore> BlockTree<K> {
         wb.set_children(&block.justify.block, &siblings);
 
         // Consider updating highest qc.
-        let update_highest_qc = block.justify.view > self.highest_qc().view;
-        if update_highest_qc {
+        if block.justify.view > self.highest_qc().view {
             wb.set_highest_qc(&block.justify);
+            update_highest_qc = Some(block.justify.clone())
         }
 
         // If block does not ancestors, return.
         if block.justify.is_genesis_qc() {
             self.write(wb);
-
-            // we publish events that change persistent state right after the corresponding changes are written to the Block Tree
-            Event::publish(event_publisher, Event::InsertBlock(InsertBlockEvent {timestamp: SystemTime::now(), block: block.clone()}));
-            if update_highest_qc {
-                Event::publish(event_publisher, Event::UpdateHighestQC(UpdateHighestQCEvent {timestamp: SystemTime::now(), highest_qc: block.justify.clone()}))
-            };
+            Self::publish_insert_block_events(event_publisher, block.clone(), update_highest_qc, update_locked_view, Vec::new());
             return None;
         }
 
         // Otherwise, do things to ancestors according to whether the block contains a commit qc or a generic qc.
-        let (mut validator_set_updates, committed_blocks) = match block.justify.phase {
+        let committed_blocks = match block.justify.phase {
             Phase::Generic => {
                 // Consider setting locked view to parent.justify.view.
                 let parent = block.justify.block;
@@ -198,6 +194,7 @@ impl<K: KVStore> BlockTree<K> {
                     let parent_justify = self.block_justify(&parent).unwrap();
                     if parent_justify.is_genesis_qc() {
                         self.write(wb);
+                        Self::publish_insert_block_events(event_publisher, block.clone(), update_highest_qc, update_locked_view, Vec::new());
                         return None;
                     }
 
@@ -205,6 +202,7 @@ impl<K: KVStore> BlockTree<K> {
                     let grandparent_justify = self.block_justify(&grandparent).unwrap();
                     if grandparent_justify.is_genesis_qc() {
                         self.write(wb);
+                        Self::publish_insert_block_events(event_publisher, block.clone(), update_highest_qc, update_locked_view, Vec::new());
                         return None;
                     }
 
@@ -233,30 +231,45 @@ impl<K: KVStore> BlockTree<K> {
 
         self.write(wb);
 
-        // we publish events that change persistent state right after the corresponding changes are written to the Block Tree
-        // TODO: abstract this
-        Event::publish(event_publisher, Event::InsertBlock(InsertBlockEvent {timestamp: SystemTime::now(), block: block.clone()}));
-        if update_highest_qc {
-            Event::publish(event_publisher, Event::UpdateHighestQC(UpdateHighestQCEvent {timestamp: SystemTime::now(), highest_qc: block.justify.clone()}))
-        };
-        if let Some(locked_view) = update_locked_view {
-            Event::publish(event_publisher, Event::UpdateLockedView(UpdateLockedViewEvent {timestamp: SystemTime::now(), locked_view}))
-        };
-        committed_blocks
-        .iter()
-        .for_each(|(b, validator_set_updates_opt)| {
-            Event::publish(event_publisher, Event::PruneBlock(PruneBlockEvent{timestamp: SystemTime::now(), block: *b}));
-            Event::publish(event_publisher, Event::CommitBlock(CommitBlockEvent{timestamp: SystemTime::now(), block: *b}));
-            if let Some(validator_set_updates) = validator_set_updates_opt {
-                Event::publish(event_publisher, Event::UpdateValidatorSet(UpdateValidatorSetEvent { timestamp: SystemTime::now(), cause_block: *b, validator_set_updates: validator_set_updates.clone()}));
-            }
-        });
+        Self::publish_insert_block_events(event_publisher, block.clone(), update_highest_qc, update_locked_view, committed_blocks.clone());
 
         // Safety: a block that updates the validator set must be followed by a block that contains
         // a commit qc. A block becomes committed immediately if followed by a commit qc. Therefore,
         // under normal operation, at most 1 validator-set-updating block can be committed by one
         // insertion.
-        validator_set_updates.pop()
+        committed_blocks.into_iter().rev().find_map(|(_, validator_set_updates_opt)| validator_set_updates_opt)
+    }
+
+    /// Publish all events resulting from calling insert_block on a block, 
+    /// These events change persistent state, and always include InsertBlockEvent, 
+    /// possibly include: UpdateHighestQCEvent, UpdatedLockedViewEvent, PruneBlockEvent, CommitBlockEvent, UpdateValidatorSetEvent
+    /// Invariant: invoked immediately after the corresponding changes are written to the Block Tree
+    fn publish_insert_block_events(
+        event_publisher: &Option<Sender<Event>>,
+        block: Block,
+        update_highest_qc: Option<QuorumCertificate>,
+        update_locked_view: Option<ViewNumber>,
+        committed_blocks: Vec<(CryptoHash, Option<ValidatorSetUpdates>)>
+    ) {
+        Event::publish(event_publisher, Event::InsertBlock(InsertBlockEvent { timestamp: SystemTime::now(), block}));
+
+        if let Some(highest_qc) = update_highest_qc {
+            Event::publish(event_publisher, Event::UpdateHighestQC(UpdateHighestQCEvent { timestamp: SystemTime::now(), highest_qc}))
+        };
+
+        if let Some(locked_view) = update_locked_view {
+            Event::publish(event_publisher, Event::UpdateLockedView(UpdateLockedViewEvent { timestamp: SystemTime::now(), locked_view}))
+        };
+
+        committed_blocks
+        .iter()
+        .for_each(|(b, validator_set_updates_opt)| {
+            Event::publish(event_publisher, Event::PruneBlock(PruneBlockEvent { timestamp: SystemTime::now(), block: *b}));
+            Event::publish(event_publisher, Event::CommitBlock(CommitBlockEvent { timestamp: SystemTime::now(), block: *b}));
+            if let Some(validator_set_updates) = validator_set_updates_opt {
+                Event::publish(event_publisher, Event::UpdateValidatorSet(UpdateValidatorSetEvent { timestamp: SystemTime::now(), cause_block: *b, validator_set_updates: validator_set_updates.clone()}));
+            }
+        });
     }
 
     pub fn set_highest_qc(&mut self, qc: &QuorumCertificate) {
@@ -279,15 +292,14 @@ impl<K: KVStore> BlockTree<K> {
         &mut self,
         wb: &mut BlockTreeWriteBatch<K::WriteBatch>,
         block: &CryptoHash,
-    ) -> (Vec<ValidatorSetUpdates>, Vec<(CryptoHash, Option<ValidatorSetUpdates>)>) {
+    ) -> Vec<(CryptoHash, Option<ValidatorSetUpdates>)> {
         let min_height = self.highest_committed_block_height();
         let blocks_iter = successors(Some(*block), |b| self.block_justify(b).map(|qc| qc.block));
         let uncommitted_blocks_iter = blocks_iter.take_while(|b| min_height.is_none() || min_height.is_some_and(|h| self.block_height(b).unwrap() > h));
         let uncommitted_blocks = uncommitted_blocks_iter.collect::<Vec<CryptoHash>>();
         let uncommitted_blocks_ordered_iter = uncommitted_blocks.iter().rev();
-        let mut committed_blocks = Vec::new();
 
-        let helper = |mut validator_set_updates: Vec<ValidatorSetUpdates>, b: &CryptoHash| ->  Vec<ValidatorSetUpdates> {
+        let helper = |mut committed_blocks: Vec<(CryptoHash, Option<ValidatorSetUpdates>)>, b: &CryptoHash| ->  Vec<(CryptoHash, Option<ValidatorSetUpdates>)>{
 
             let block_height = self.block_height(b).unwrap();
             // Work steps:
@@ -312,8 +324,8 @@ impl<K: KVStore> BlockTree<K> {
 
                 wb.set_committed_validator_set(&committed_validator_set);
                 wb.delete_pending_validator_set_updates(block);
+
                 committed_blocks.push((*b, Some(pending_validator_set_updates.clone())));
-                validator_set_updates.push(pending_validator_set_updates);
             } else {
                 committed_blocks.push((*b, None));
             }
@@ -321,11 +333,11 @@ impl<K: KVStore> BlockTree<K> {
             // Update the highest committed block.
             wb.set_highest_committed_block(b);
 
-            validator_set_updates
+            // Committed blocks so far with their corresponding validator set updates
+            committed_blocks
         };
 
-        let init_updates = Vec::new();
-        (uncommitted_blocks_ordered_iter.fold(init_updates, helper), committed_blocks)
+        uncommitted_blocks_ordered_iter.fold(Vec::new(), helper)
 
     }
 

--- a/src/sync_server.rs
+++ b/src/sync_server.rs
@@ -27,7 +27,6 @@
 //!       into its block tree, and then jumps back to step 2.
 
 use crate::events::{Event, ReceiveSyncRequestEvent, SendSyncResponseEvent};
-//use crate::logging::debug;
 use crate::messages::{SyncRequest, SyncResponse};
 use crate::networking::{Network, SyncServerStub};
 use crate::state::{BlockTreeCamera, KVStore};
@@ -60,16 +59,16 @@ pub(crate) fn start_sync_server<K: KVStore, N: Network + 'static>(
             },
         )) = sync_stub.recv_request()
         {
-            Event::publish(&event_publisher, Event::ReceiveSyncRequest(ReceiveSyncRequestEvent { timestamp: SystemTime::now(), peer: origin.clone(), start_height, limit}));
+            Event::publish(&event_publisher, Event::ReceiveSyncRequest(ReceiveSyncRequestEvent { timestamp: SystemTime::now(), peer: origin, start_height, limit}));
 
             let bt_snapshot = block_tree.snapshot();
             let blocks = bt_snapshot
                 .blocks_from_height_to_newest(start_height, max(limit, server_sync_request_limit));
             let highest_qc = bt_snapshot.highest_qc();
 
-            sync_stub.send_response(origin, SyncResponse {blocks: blocks.clone(), highest_qc: highest_qc.clone() });
+            sync_stub.send_response(origin, SyncResponse { blocks: blocks.clone(), highest_qc: highest_qc.clone() });
 
-            Event::publish(&event_publisher, Event::SendSyncResponse(SendSyncResponseEvent {timestamp: SystemTime::now(), peer: origin.clone(), blocks: blocks.clone(), highest_qc: highest_qc.clone()}))
+            Event::publish(&event_publisher, Event::SendSyncResponse(SendSyncResponseEvent { timestamp: SystemTime::now(), peer: origin, blocks, highest_qc}))
         }
         thread::yield_now();
     })

--- a/src/sync_server.rs
+++ b/src/sync_server.rs
@@ -26,19 +26,22 @@
 //!     - If it does contain new blocks, then the replica validates the blocks and quorum certificate and inserts them
 //!       into its block tree, and then jumps back to step 2.
 
-use crate::logging::debug;
+use crate::events::{Event, ReceiveSyncRequestEvent, SendSyncResponseEvent};
+//use crate::logging::debug;
 use crate::messages::{SyncRequest, SyncResponse};
 use crate::networking::{Network, SyncServerStub};
 use crate::state::{BlockTreeCamera, KVStore};
 use std::cmp::max;
-use std::sync::mpsc::{Receiver, TryRecvError};
+use std::sync::mpsc::{Receiver, TryRecvError, Sender};
 use std::thread::{self, JoinHandle};
+use std::time::SystemTime;
 
 pub(crate) fn start_sync_server<K: KVStore, N: Network + 'static>(
     block_tree: BlockTreeCamera<K>,
     mut sync_stub: SyncServerStub<N>,
     shutdown_signal: Receiver<()>,
     server_sync_request_limit: u32,
+    event_publisher: Option<Sender<Event>>,
 ) -> JoinHandle<()> {
     thread::spawn(move || loop {
         match shutdown_signal.try_recv() {
@@ -57,14 +60,16 @@ pub(crate) fn start_sync_server<K: KVStore, N: Network + 'static>(
             },
         )) = sync_stub.recv_request()
         {
-            debug::received_sync_request(&origin);
+            Event::publish(&event_publisher, Event::ReceiveSyncRequest(ReceiveSyncRequestEvent { timestamp: SystemTime::now(), peer: origin.clone(), start_height, limit}));
 
             let bt_snapshot = block_tree.snapshot();
             let blocks = bt_snapshot
                 .blocks_from_height_to_newest(start_height, max(limit, server_sync_request_limit));
             let highest_qc = bt_snapshot.highest_qc();
 
-            sync_stub.send_response(origin, SyncResponse { blocks, highest_qc });
+            sync_stub.send_response(origin, SyncResponse {blocks: blocks.clone(), highest_qc: highest_qc.clone() });
+
+            Event::publish(&event_publisher, Event::SendSyncResponse(SendSyncResponseEvent {timestamp: SystemTime::now(), peer: origin.clone(), blocks: blocks.clone(), highest_qc: highest_qc.clone()}))
         }
         thread::yield_now();
     })


### PR DESCRIPTION
This PR introduces the event handling feature for `hotstuff-rs`, as well as logging rewritten as a set of possible default event handlers. The major contributions include:

1. `events.rs`: definitions of key blockchain and protocol events
2. `event_bus.rs`: `EventHandlers` struct for storing handlers for each event type, including a method to add default logging handlers, `event_bus` thread for receiving events from `algorithm `and `sync_server` threads and triggering the execution of appropriate handlers stored in its instance of the `EventHandlers` struct
3. `logging.rs`: `Logger` trait with a required method `get_logger()` which returns an object's default handler for logging, implementations of the `Logger` trait for all event types from `events.rs`
4. `replica.rs`: `log_events: bool ` and a vector of handlers for each event type passed as parameters to `Replica.start() `, creating an `EventHandlers` struct based on provided handlers and `log_events`, if the struct instance is not empty then `Replica.start() ` launches an extra thread `event_bus` for triggering the execution of event handlers upon receiving events
5. `algorithm.rs`, `state.rs`, `sync_server.rs`: relevant functions now publish events by sending them on the `event_publisher` end of the channel. The events are published after the corresponding action is completed, in particular events that modify the block tree are only published after the event takes effect, i.e, the change is written to the block tree (rather than a write batch)