### PR TITLE
Replica Builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,10 @@ categories = ["cryptography::cryptocurrencies", "concurrency"]
 [dependencies]
 base64 = "0.21"
 borsh = "0.10"
-ed25519-dalek = "2.0.0"
+ed25519-dalek = { version = "2.0.0", features = ["rand_core"] }
 fern = "0.6"
 log = "0.4" 
 rand = "0.7"
+rand_core = { version = "0.6.4", features = ["getrandom"] }
 sha2 = "0.10"
+typed-builder = "0.16.2"

--- a/src/events.rs
+++ b/src/events.rs
@@ -38,7 +38,7 @@ pub enum Event {
 impl Event {
     pub(crate) fn publish(event_publisher: &Option<Sender<Event>>, event: Event) {
         if let Some(event_publisher) = event_publisher {
-            event_publisher.send(event).unwrap()
+            let _ = event_publisher.send(event);
         }
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -49,7 +49,7 @@ pub const SEND_SYNC_RESPONSE: &str = "SentSyncResponse";
 impl Logger for InsertBlockEvent {
     fn get_logger() -> Box<dyn Fn(&Self) + Send> {
         let logger = |insert_block_event: &InsertBlockEvent| {
-            log::debug!(
+            log::info!(
                 "{}, {:?}, {}, {}",
                 INSERT_BLOCK,
                 insert_block_event.timestamp,
@@ -190,7 +190,7 @@ impl Logger for NewViewEvent {
 impl Logger for ReceiveProposalEvent {
     fn get_logger() -> Box<dyn Fn(&Self) + Send> {
         let logger = |receive_proposal_event: &ReceiveProposalEvent| {
-            log::debug!(
+            log::info!(
                 "{}, {:?}, {}, {}, {}",
                 RECEIVED_PROPOSAL,
                 receive_proposal_event.timestamp,
@@ -206,7 +206,7 @@ impl Logger for ReceiveProposalEvent {
 impl Logger for ReceiveNudgeEvent {
     fn get_logger() -> Box<dyn Fn(&Self) + Send> {
         let logger = |receive_nudge_event: &ReceiveNudgeEvent| {
-            log::debug!(
+            log::info!(
                 "{}, {:?}, {}, {}, {:?}",
                 RECEIVED_NUDGE,
                 receive_nudge_event.timestamp,
@@ -222,7 +222,7 @@ impl Logger for ReceiveNudgeEvent {
 impl Logger for ReceiveVoteEvent {
     fn get_logger() -> Box<dyn Fn(&Self) + Send> {
         let logger = |receive_vote_event: &ReceiveVoteEvent| {
-            log::debug!(
+            log::info!(
                 "{}, {:?}, {}, {}, {:?}",
                 RECEIVED_VOTE,
                 receive_vote_event.timestamp,
@@ -238,7 +238,7 @@ impl Logger for ReceiveVoteEvent {
 impl Logger for ReceiveNewViewEvent {
     fn get_logger() -> Box<dyn Fn(&Self) + Send> {
         let logger = |receive_new_view_event: &ReceiveNewViewEvent| {
-            log::debug!(
+            log::info!(
                 "{}, {:?}, {}, {}, {}, {:?}",
                 RECEIVED_NEW_VIEW,
                 receive_new_view_event.timestamp,
@@ -255,7 +255,7 @@ impl Logger for ReceiveNewViewEvent {
 impl Logger for StartViewEvent {
     fn get_logger() -> Box<dyn Fn(&Self) + Send> {
         let logger = |start_view_event: &StartViewEvent| {
-            log::debug!(
+            log::info!(
                 "{}, {:?}, {}, {}",
                 START_VIEW,
                 start_view_event.timestamp,

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -148,10 +148,10 @@ pub struct SyncResponse {
 
 /// A wrapper around SigningKey which implements [a convenience method](ProgressMessage::vote) for creating properly
 /// signed [votes](Vote).
-pub(crate) struct Keypair(pub(crate) PrivateKey);
+pub(crate) struct Keypair(pub(crate) SigningKey);
 
 impl Keypair {
-    pub(crate) fn new(private_key: PrivateKey) -> Keypair {
+    pub(crate) fn new(private_key: SigningKey) -> Keypair {
         Keypair(private_key)
     }
 

--- a/src/replica.rs
+++ b/src/replica.rs
@@ -34,96 +34,114 @@ use crate::networking::{
 use crate::pacemaker::Pacemaker;
 use crate::state::{BlockTree, BlockTreeCamera, KVStore};
 use crate::sync_server::start_sync_server;
-use crate::types::{AppStateUpdates, ValidatorSetUpdates, PrivateKey};
+use crate::types::{AppStateUpdates, ValidatorSetUpdates, PrivateKey, ChainID};
 use std::sync::mpsc::{self, Sender};
 use std::thread::JoinHandle;
+use std::time::Duration;
+use typed_builder::TypedBuilder;
 
-pub struct Replica<K: KVStore> {
-    block_tree_camera: BlockTreeCamera<K>,
-    poller: Option<JoinHandle<()>>,
-    poller_shutdown: Sender<()>,
-    algorithm: Option<JoinHandle<()>>,
-    algorithm_shutdown: Sender<()>,
-    sync_server: Option<JoinHandle<()>>,
-    sync_server_shutdown: Sender<()>,
-    event_bus: Option<JoinHandle<()>>,
-    event_bus_shutdown: Option<Sender<()>>,
+#[derive(TypedBuilder)]
+pub struct Configuration {
+    pub me: PrivateKey,
+    pub chain_id: ChainID,
+    pub sync_trigger_timeout: Duration,
+    pub sync_request_limit: u64,
+    pub sync_response_timeout: Duration,
+    pub progress_msg_buffer_capacity: u64,
+    pub log_events: bool,
 }
 
-impl<K: KVStore> Replica<K> {
-    pub fn initialize(
-        kv_store: K,
-        initial_app_state: AppStateUpdates,
-        initial_validator_set: ValidatorSetUpdates,
-    ) {
-        let mut block_tree = BlockTree::new(kv_store);
-        block_tree.initialize(&initial_app_state, &initial_validator_set);
-    }
+#[derive(TypedBuilder)]
+pub struct ReplicaBuilder<K: KVStore, A: App<K> + 'static, N: Network + 'static, P: Pacemaker + 'static> {
+    // Required parameters
+    app: A,
+    network: N,
+    kv_store: K,
+    pacemaker: P,
+    configuration: Configuration,
+    // Optional parameters
+    #[builder(default, setter(transform = |on_insert_block: HandlerPtr<InsertBlockEvent>| vec![on_insert_block]))]
+    insert_block_handlers: Vec<HandlerPtr<InsertBlockEvent>>,
+    #[builder(default, setter(transform = |on_commit_block: HandlerPtr<CommitBlockEvent>| vec![on_commit_block]))]
+    commit_block_handlers: Vec<HandlerPtr<CommitBlockEvent>>,
+    #[builder(default, setter(transform = |on_prune_block: HandlerPtr<PruneBlockEvent>| vec![on_prune_block]))]
+    prune_block_handlers: Vec<HandlerPtr<PruneBlockEvent>>,
+    #[builder(default, setter(transform = |on_update_highest_qc: HandlerPtr<UpdateHighestQCEvent>| vec![on_update_highest_qc]))]
+    update_highest_qc_handlers: Vec<HandlerPtr<UpdateHighestQCEvent>>,
+    #[builder(default, setter(transform = |on_update_locked_view: HandlerPtr<UpdateLockedViewEvent>| vec![on_update_locked_view]))]
+    update_locked_view_handlers: Vec<HandlerPtr<UpdateLockedViewEvent>>,
+    #[builder(default, setter(transform = |on_update_validator_set: HandlerPtr<UpdateValidatorSetEvent>| vec![on_update_validator_set]))]
+    update_validator_set_handlers: Vec<HandlerPtr<UpdateValidatorSetEvent>>,
+    #[builder(default, setter(transform = |on_propose: HandlerPtr<ProposeEvent>| vec![on_propose]))]
+    propose_handlers: Vec<HandlerPtr<ProposeEvent>>,
+    #[builder(default, setter(transform = |on_nudge: HandlerPtr<NudgeEvent>| vec![on_nudge]))]
+    nudge_handlers: Vec<HandlerPtr<NudgeEvent>>,
+    #[builder(default, setter(transform = |on_vote: HandlerPtr<VoteEvent>| vec![on_vote]))]
+    vote_handlers: Vec<HandlerPtr<VoteEvent>>,
+    #[builder(default, setter(transform = |on_new_view: HandlerPtr<NewViewEvent>| vec![on_new_view]))]
+    new_view_handlers: Vec<HandlerPtr<NewViewEvent>>,
+    #[builder(default, setter(transform = |on_receive_proposal: HandlerPtr<ReceiveProposalEvent>| vec![on_receive_proposal]))]
+    receive_proposal_handlers: Vec<HandlerPtr<ReceiveProposalEvent>>,
+    #[builder(default, setter(transform = |on_receive_nudge: HandlerPtr<ReceiveNudgeEvent>| vec![on_receive_nudge]))]
+    receive_nudge_handlers: Vec<HandlerPtr<ReceiveNudgeEvent>>,
+    #[builder(default, setter(transform = |on_receive_vote: HandlerPtr<ReceiveVoteEvent>| vec![on_receive_vote]))]
+    receive_vote_handlers: Vec<HandlerPtr<ReceiveVoteEvent>>,
+    #[builder(default, setter(transform = |on_receive_new_view: HandlerPtr<ReceiveNewViewEvent>| vec![on_receive_new_view]))]
+    receive_new_view_handlers: Vec<HandlerPtr<ReceiveNewViewEvent>>,
+    #[builder(default, setter(transform = |on_start_view: HandlerPtr<StartViewEvent>| vec![on_start_view]))]
+    start_view_handlers: Vec<HandlerPtr<StartViewEvent>>,
+    #[builder(default, setter(transform = |on_view_timeout: HandlerPtr<ViewTimeoutEvent>| vec![on_view_timeout]))]
+    view_timeout_handlers: Vec<HandlerPtr<ViewTimeoutEvent>>,
+    #[builder(default, setter(transform = |on_collect_qc: HandlerPtr<CollectQCEvent>| vec![on_collect_qc]))]
+    collect_qc_handlers: Vec<HandlerPtr<CollectQCEvent>>,
+    #[builder(default, setter(transform = |on_start_sync: HandlerPtr<StartSyncEvent>| vec![on_start_sync]))]
+    start_sync_handlers: Vec<HandlerPtr<StartSyncEvent>>,
+    #[builder(default, setter(transform = |on_end_sync: HandlerPtr<EndSyncEvent>| vec![on_end_sync]))]
+    end_sync_handlers: Vec<HandlerPtr<EndSyncEvent>>,
+    #[builder(default, setter(transform = |on_receive_sync_request: HandlerPtr<ReceiveSyncRequestEvent>| vec![on_receive_sync_request]))]
+    receive_sync_request_handlers: Vec<HandlerPtr<ReceiveSyncRequestEvent>>,
+    #[builder(default, setter(transform = |on_send_sync_response: HandlerPtr<SendSyncResponseEvent>| vec![on_send_sync_response]))]
+    send_sync_response_handlers: Vec<HandlerPtr<SendSyncResponseEvent>>,
+}
 
-    pub fn start(
-        app: impl App<K> + 'static,
-        private_key: PrivateKey,
-        mut network: impl Network + 'static,
-        kv_store: K,
-        pacemaker: impl Pacemaker + 'static,
-        log_events: bool,
-        insert_block_handlers: Vec<HandlerPtr<InsertBlockEvent>>,
-        commit_block_handlers: Vec<HandlerPtr<CommitBlockEvent>>,
-        prune_block_handlers: Vec<HandlerPtr<PruneBlockEvent>>,
-        update_highest_qc_handlers: Vec<HandlerPtr<UpdateHighestQCEvent>>,
-        update_locked_view_handlers: Vec<HandlerPtr<UpdateLockedViewEvent>>,
-        update_validator_set_handlers: Vec<HandlerPtr<UpdateValidatorSetEvent>>,
-        propose_handlers: Vec<HandlerPtr<ProposeEvent>>,
-        nudge_handlers: Vec<HandlerPtr<NudgeEvent>>,
-        vote_handlers: Vec<HandlerPtr<VoteEvent>>,
-        new_view_handlers: Vec<HandlerPtr<NewViewEvent>>,
-        receive_proposal_handlers: Vec<HandlerPtr<ReceiveProposalEvent>>,
-        receive_nudge_handlers: Vec<HandlerPtr<ReceiveNudgeEvent>>,
-        receive_vote_handlers: Vec<HandlerPtr<ReceiveVoteEvent>>,
-        receive_new_view_handlers: Vec<HandlerPtr<ReceiveNewViewEvent>>,
-        start_view_handlers: Vec<HandlerPtr<StartViewEvent>>,
-        view_timeout_handlers: Vec<HandlerPtr<ViewTimeoutEvent>>,
-        collect_qc_handlers: Vec<HandlerPtr<CollectQCEvent>>,
-        start_sync_handlers: Vec<HandlerPtr<StartSyncEvent>>,
-        end_sync_handlers: Vec<HandlerPtr<EndSyncEvent>>,
-        receive_sync_request_handlers: Vec<HandlerPtr<ReceiveSyncRequestEvent>>,
-        send_sync_response_handlers: Vec<HandlerPtr<SendSyncResponseEvent>>,
-    ) -> Replica<K> {
-        let block_tree = BlockTree::new(kv_store.clone());
+impl<K: KVStore, A: App<K> + 'static, N: Network + 'static, P: Pacemaker + 'static> ReplicaBuilder<K, A, N, P> {
 
-        network.init_validator_set(block_tree.committed_validator_set());
+    pub fn start(mut self) -> Replica<K> {
+        let block_tree = BlockTree::new(self.kv_store.clone());
+
+        self.network.init_validator_set(block_tree.committed_validator_set());
         let (poller_shutdown, poller_shutdown_receiver) = mpsc::channel();
         let (poller, progress_msgs, sync_requests, sync_responses) =
-            start_polling(network.clone(), poller_shutdown_receiver);
-        let pm_stub = ProgressMessageStub::new(network.clone(), progress_msgs);
-        let sync_server_stub = SyncServerStub::new(sync_requests, network.clone());
-        let sync_client_stub = SyncClientStub::new(network, sync_responses);
+            start_polling(self.network.clone(), poller_shutdown_receiver);
+        let pm_stub = ProgressMessageStub::new(self.network.clone(), progress_msgs);
+        let sync_server_stub = SyncServerStub::new(sync_requests, self.network.clone());
+        let sync_client_stub = SyncClientStub::new(self.network, sync_responses);
 
         let mut event_handlers = EventHandlers {
-            insert_block_handlers,
-            commit_block_handlers,
-            prune_block_handlers,
-            update_highest_qc_handlers,
-            update_locked_view_handlers,
-            update_validator_set_handlers,
-            propose_handlers,
-            nudge_handlers,
-            vote_handlers,
-            new_view_handlers,
-            receive_proposal_handlers,
-            receive_nudge_handlers,
-            receive_vote_handlers,
-            receive_new_view_handlers,
-            start_view_handlers,
-            view_timeout_handlers,
-            collect_qc_handlers,
-            start_sync_handlers,
-            end_sync_handlers,
-            receive_sync_request_handlers,
-            send_sync_response_handlers
+            insert_block_handlers: self.insert_block_handlers,
+            commit_block_handlers: self.commit_block_handlers,
+            prune_block_handlers: self.prune_block_handlers,
+            update_highest_qc_handlers: self.update_highest_qc_handlers,
+            update_locked_view_handlers: self.update_locked_view_handlers,
+            update_validator_set_handlers: self.update_validator_set_handlers,
+            propose_handlers: self.propose_handlers,
+            nudge_handlers: self.nudge_handlers,
+            vote_handlers: self.vote_handlers,
+            new_view_handlers: self.new_view_handlers,
+            receive_proposal_handlers: self.receive_proposal_handlers,
+            receive_nudge_handlers: self.receive_nudge_handlers,
+            receive_vote_handlers: self.receive_vote_handlers,
+            receive_new_view_handlers: self.receive_new_view_handlers,
+            start_view_handlers: self.start_view_handlers,
+            view_timeout_handlers: self.view_timeout_handlers,
+            collect_qc_handlers: self.collect_qc_handlers,
+            start_sync_handlers: self.start_sync_handlers,
+            end_sync_handlers: self.end_sync_handlers,
+            receive_sync_request_handlers: self.receive_sync_request_handlers,
+            send_sync_response_handlers: self.send_sync_response_handlers
         };
 
-        if log_events {
+        if self.configuration.log_events {
             event_handlers.add_logging_handlers();
         };
 
@@ -134,19 +152,19 @@ impl<K: KVStore> Replica<K> {
 
         let (sync_server_shutdown, sync_server_shutdown_receiver) = mpsc::channel();
         let sync_server = start_sync_server(
-            BlockTreeCamera::new(kv_store.clone()),
+            BlockTreeCamera::new(self.kv_store.clone()),
             sync_server_stub,
             sync_server_shutdown_receiver,
-            pacemaker.sync_request_limit(),
+            self.pacemaker.sync_request_limit(),
             event_publisher.clone(),
         );
 
         let (algorithm_shutdown, algorithm_shutdown_receiver) = mpsc::channel();
         let algorithm = start_algorithm(
-            app,
-            messages::Keypair::new(private_key),
+            self.app,
+            messages::Keypair::new(self.configuration.me),
             block_tree,
-            pacemaker,
+            self.pacemaker,
             pm_stub,
             sync_client_stub,
             algorithm_shutdown_receiver,
@@ -171,7 +189,7 @@ impl<K: KVStore> Replica<K> {
         };
         
         Replica {
-            block_tree_camera: BlockTreeCamera::new(kv_store),
+            block_tree_camera: BlockTreeCamera::new(self.kv_store),
             poller: Some(poller),
             poller_shutdown,
             algorithm: Some(algorithm),
@@ -181,6 +199,29 @@ impl<K: KVStore> Replica<K> {
             event_bus,
             event_bus_shutdown,
         }
+    }
+}
+
+pub struct Replica<K: KVStore> {
+    block_tree_camera: BlockTreeCamera<K>,
+    poller: Option<JoinHandle<()>>,
+    poller_shutdown: Sender<()>,
+    algorithm: Option<JoinHandle<()>>,
+    algorithm_shutdown: Sender<()>,
+    sync_server: Option<JoinHandle<()>>,
+    sync_server_shutdown: Sender<()>,
+    event_bus: Option<JoinHandle<()>>,
+    event_bus_shutdown: Option<Sender<()>>,
+}
+
+impl<K: KVStore> Replica<K> {
+    pub fn initialize(
+        kv_store: K,
+        initial_app_state: AppStateUpdates,
+        initial_validator_set: ValidatorSetUpdates,
+    ) {
+        let mut block_tree = BlockTree::new(kv_store);
+        block_tree.initialize(&initial_app_state, &initial_validator_set);
     }
 
     pub fn block_tree_camera(&self) -> &BlockTreeCamera<K> {

--- a/src/state.rs
+++ b/src/state.rs
@@ -294,7 +294,14 @@ impl<K: KVStore> BlockTree<K> {
         block: &CryptoHash,
     ) -> Vec<(CryptoHash, Option<ValidatorSetUpdates>)> {
         let min_height = self.highest_committed_block_height();
-        let blocks_iter = successors(Some(*block), |b| self.block_justify(b).map(|qc| qc.block));
+        let blocks_iter =
+            successors(
+            Some(*block), 
+            |b| 
+                self.block_justify(b)
+                .map(|qc| if !qc.is_genesis_qc() {Some(qc.block)} else {None})
+                .flatten()
+            );
         let uncommitted_blocks_iter = blocks_iter.take_while(|b| min_height.is_none() || min_height.is_some_and(|h| self.block_height(b).unwrap() > h));
         let uncommitted_blocks = uncommitted_blocks_iter.collect::<Vec<CryptoHash>>();
         let uncommitted_blocks_ordered_iter = uncommitted_blocks.iter().rev();

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,7 +16,7 @@ use std::{
     slice,
 };
 
-pub use ed25519_dalek::{SigningKey as PrivateKey, VerifyingKey as PublicKey, Signature};
+pub use ed25519_dalek::{SigningKey, VerifyingKey as PublicKey, Signature};
 pub use sha2::Sha256 as CryptoHasher;
 
 pub type ChainID = u64;


### PR DESCRIPTION
Implemented a builder pattern for replica, now a replica can be started as follows:
```
let replica = 
            ReplicaBuilder :: builder()
            .app(app)
            .pacemaker(pacemaker)
            .network(network)
            .kv_store(kv_store)
            .configuration(configuration)
            .on_insert_block(on_insert_block)
            .on_commit_block(on_commit_block)
            //...
            .build()
            .start();
```
Where `on_<event>` setters are optional, but if used they should be passed arguments of type `HandlerPtr<event_type>`, e.g. the `on_insert_block` setter takes an argument of type `HandlerPtr<InsertBlockEvent>`, which is the same as `Box<dyn Fn(&InsertBlockEvent) + Send>`. Therefore, the argument must be a pointer to the closure, rather than the closure itself (the popinter can be created with `Box::new(handler)` where handler is a closure that implements `Fn(&event_type)`). This is because `Fn(&T)` is a trait which can be implemented by different types thus with size unknown at compile time, and so cannot be stored in a struct's field which should have a size known at compile time.

Note that even though we pass only one closure pointer per event, the closure can in fact be defined to combine multiple different closures. Hence, passing one closure can be equivalent to passing multiple closures.

However, internally the handlers for each event are stored as a vector `Vec<HandlerPtr<event_type>>` which can include (1) (optionally) a custom handler passed to the replica builder, and (2) (optionally, if `log_events` is set to `true` in configuration) a predefined log handler for the event (from `logging.rs`). This is to avoid combining the user-provided closure with the logging closure by dereferencing ("unboxing") the user-provided closure, just to "box" the resulting closure again after combing the functionalities of the two.

Other changes:

1. Modified tests to make them compatible with the `ed25519-dalek` update, event handlers and the builder pattern for replica (this required including the `rand_core` feature for `ed25519-dalek` in `Cargo.toml`, and adding `rand_core` to dependencies)
2. Minor fixes, switch to using `log::info` in all loggers in `logging.rs`