### PR TITLE
0.4 pacemaker

### DIFF
--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -60,7 +60,7 @@ impl<N: Network + 'static, K: KVStore, A: App<K> + 'static> Algorithm<N, K, A> {
         let validator_set_update_handle = ValidatorSetUpdateHandle::new(network);
 
         let init_view = 
-            match block_tree.highest_view_with_progress().get_int() {
+            match block_tree.highest_view_with_progress().int() {
                 0 => ViewNumber::new(0),
                 v => ViewNumber::new(v+1)
             };

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -27,7 +27,7 @@ use crate::types::basic::{BufferSize, ChainID, ViewNumber};
 
 pub(crate) struct Algorithm<N: Network + 'static, K: KVStore, A: App<K> + 'static> {
     chain_id: ChainID,
-    pm_stub: ProgressMessageStub<N>,
+    pm_stub: ProgressMessageStub,
     block_tree: BlockTree<K>,
     app: A,
     hotstuff: HotStuff<N>,
@@ -54,10 +54,10 @@ impl<N: Network + 'static, K: KVStore, A: App<K> + 'static> Algorithm<N, K, A> {
         progress_msg_buffer_capacity: BufferSize,
     ) -> Self {
 
-        let pm_stub = ProgressMessageStub::new(network.clone(), progress_msg_receiver, progress_msg_buffer_capacity);
-        let block_sync_client_stub = BlockSyncClientStub::new(network.clone(), block_sync_response_receiver);
+        let pm_stub = ProgressMessageStub::new(progress_msg_receiver, progress_msg_buffer_capacity);
+        let block_sync_client_stub = BlockSyncClientStub::new(block_sync_response_receiver);
         let msg_sender: SenderHandle<N> = SenderHandle::new(network.clone());
-        let validator_set_update_handle = ValidatorSetUpdateHandle::new(network.clone());
+        let validator_set_update_handle = ValidatorSetUpdateHandle::new(network);
 
         let init_view = 
             match block_tree.highest_view_with_progress().get_int() {

--- a/src/block_sync/client.rs
+++ b/src/block_sync/client.rs
@@ -48,7 +48,7 @@ impl<N: Network> BlockSyncClient<N> {
         }
     }
 
-    pub(crate) fn on_receive_msg<K: KVStore>(&mut self, msg: BlockSyncTriggerMessage, origin: VerifyingKey, block_tree: &BlockTree<K>) {
+    pub(crate) fn on_receive_msg<K: KVStore>(&mut self, msg: BlockSyncTriggerMessage, origin: &VerifyingKey, block_tree: &BlockTree<K>) {
         todo!()
     }
 

--- a/src/block_sync/client.rs
+++ b/src/block_sync/client.rs
@@ -22,7 +22,7 @@ use super::messages::{BlockSyncRequest, BlockSyncTriggerMessage};
 
 pub(crate) struct BlockSyncClient<N: Network> {
     config: BlockSyncClientConfiguration,
-    receiver: BlockSyncClientStub<N>,
+    receiver: BlockSyncClientStub,
     sender: SenderHandle<N>,
     validator_set_update_handle: ValidatorSetUpdateHandle<N>,
     block_sync_client_state: BlockSyncClientState,
@@ -33,7 +33,7 @@ impl<N: Network> BlockSyncClient<N> {
 
     pub(crate) fn new(
         config: BlockSyncClientConfiguration,
-        receiver: BlockSyncClientStub<N>,
+        receiver: BlockSyncClientStub,
         sender: SenderHandle<N>,
         validator_set_update_handle: ValidatorSetUpdateHandle<N>,
         event_publisher: Option<Sender<Event>>,

--- a/src/block_sync/messages.rs
+++ b/src/block_sync/messages.rs
@@ -8,10 +8,11 @@
 
 use borsh::{BorshDeserialize, BorshSerialize};
 
-use crate::{hotstuff::types::QuorumCertificate, messages::{Message, ProgressMessage}, types::{
-    basic::*,
-    block::*,
-}};
+use crate::{
+    hotstuff::types::QuorumCertificate, 
+    messages::{Message, ProgressMessage}, 
+    types::{basic::*,block::*}
+};
 
 #[derive(Clone, BorshSerialize, BorshDeserialize)]
 pub enum BlockSyncMessage {
@@ -37,22 +38,10 @@ pub struct BlockSyncRequest {
     pub limit: u32,
 }
 
-impl Into<Message> for BlockSyncRequest {
-    fn into(self) -> Message {
-        Message::BlockSyncMessage(BlockSyncMessage::BlockSyncRequest(self))
-    }
-}
-
 #[derive(Clone, BorshSerialize, BorshDeserialize)]
 pub struct BlockSyncResponse {
     pub blocks: Vec<Block>,
     pub highest_qc: QuorumCertificate,
-}
-
-impl Into<Message> for BlockSyncResponse {
-    fn into(self) -> Message {
-        Message::BlockSyncMessage(BlockSyncMessage::BlockSyncResponse(self))
-    }
 }
 
 // Messages that may trigger sync, exchanged as part of the normal progress protocol.
@@ -73,14 +62,4 @@ pub struct AdvertiseBlock {
     pub block: CryptoHash,
     pub block_qc: QuorumCertificate, // highest known qc for the block
     //TODO: pub signature: SignatureBytes, // necessary to authenticate the sender of this message!
-}
-
-impl Into<Message> for AdvertiseBlock {
-    fn into(self) -> Message {
-        Message::ProgressMessage(ProgressMessage::
-            BlockSyncTriggerMessage(BlockSyncTriggerMessage::
-                AdvertiseBlock(self)
-            )
-        )
-    }
 }

--- a/src/block_sync/messages.rs
+++ b/src/block_sync/messages.rs
@@ -6,6 +6,8 @@
 //! Definitions for structured messages that are sent between replicas as part of the [BlockSync] protocol.
 //! Note: the struct definitions may be subject to change as we flesh out the details of the [BlockSync] protocol.
 
+use std::mem;
+
 use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::{
@@ -54,6 +56,19 @@ impl BlockSyncTriggerMessage {
     pub fn advertise_block(chain_id: ChainID, block: CryptoHash, block_qc: QuorumCertificate) -> Self {
         BlockSyncTriggerMessage::AdvertiseBlock(AdvertiseBlock{chain_id, block, block_qc})
     }
+
+    pub fn chain_id(&self) -> ChainID {
+        match self {
+            BlockSyncTriggerMessage::AdvertiseBlock(msg) => msg.chain_id
+        }
+    }
+
+    pub fn size(&self) -> u64 {
+        match self {
+            BlockSyncTriggerMessage::AdvertiseBlock(msg) => mem::size_of::<AdvertiseBlock>() as u64,
+        }
+    }
+
 }
 
 #[derive(Clone, BorshSerialize, BorshDeserialize)]

--- a/src/hotstuff/messages.rs
+++ b/src/hotstuff/messages.rs
@@ -117,12 +117,6 @@ impl HotStuffMessage {
     }
 }
 
-impl Into<Message> for HotStuffMessage {
-    fn into(self) -> Message {
-        Message::ProgressMessage(ProgressMessage::HotStuffMessage(self))
-    }
-}
-
 #[derive(Clone, BorshSerialize, BorshDeserialize)]
 pub struct Proposal {
     pub chain_id: ChainID,

--- a/src/hotstuff/messages.rs
+++ b/src/hotstuff/messages.rs
@@ -10,7 +10,7 @@ use std::mem;
 use borsh::{BorshDeserialize, BorshSerialize};
 use ed25519_dalek::{Verifier};
 
-use crate::messages::{Message, ProgressMessage, SignedMessage};
+use crate::messages::{Cacheable, Message, ProgressMessage, SignedMessage};
 use crate::types::{
     basic::*, 
     block::*, 
@@ -114,6 +114,22 @@ impl HotStuffMessage {
             HotStuffMessage::Vote(_) => mem::size_of::<Vote>() as u64,
             HotStuffMessage::NewView(_) => mem::size_of::<NewView>() as u64,
         }
+    }
+}
+
+impl Cacheable for HotStuffMessage {
+    fn size(&self) -> u64 {
+        self.size()
+    }
+
+    fn view(&self) -> ViewNumber {
+        self.view()
+    }
+}
+
+impl Into<ProgressMessage> for HotStuffMessage {
+    fn into(self) -> ProgressMessage {
+        ProgressMessage::HotStuffMessage(self)
     }
 }
 

--- a/src/hotstuff/protocol.rs
+++ b/src/hotstuff/protocol.rs
@@ -14,6 +14,7 @@ use ed25519_dalek::VerifyingKey;
 use crate::app::App;
 use crate::events::Event;
 use crate:: networking::{Network, SenderHandle, ValidatorSetUpdateHandle};
+use crate::pacemaker::protocol::ViewInfo;
 use crate::state::{BlockTree, KVStore};
 use crate::types::validators::ValidatorSet;
 use crate::types::{
@@ -31,6 +32,7 @@ use crate::hotstuff::types::{NewViewCollector, VoteCollector};
 pub(crate) struct HotStuff<N: Network> {
     config: HotStuffConfiguration,
     state: HotStuffState,
+    view_info: ViewInfo,
     sender_handle: SenderHandle<N>,
     validator_set_update_handle: ValidatorSetUpdateHandle<N>,
     event_publisher: Option<Sender<Event>>,
@@ -40,23 +42,20 @@ impl<N: Network> HotStuff<N> {
 
     pub(crate) fn new(
         config: HotStuffConfiguration,
+        view_info: ViewInfo,
         sender_handle: SenderHandle<N>,
         validator_set_update_handle: ValidatorSetUpdateHandle<N>,
-        init_view: ViewNumber,
-        init_leader: VerifyingKey,
-        next_leader: VerifyingKey,
         init_validator_set: ValidatorSet,
         event_publisher: Option<Sender<Event>>,
     ) -> Self {
         let state = HotStuffState::new(
             config.clone(), 
-            init_view, 
-            init_leader, 
-            next_leader, 
+            view_info.view, 
             init_validator_set
         );
         Self { 
             config,
+            view_info,
             state,
             sender_handle, 
             validator_set_update_handle, 
@@ -64,11 +63,9 @@ impl<N: Network> HotStuff<N> {
         }
     }
 
-    pub(crate) fn on_enter_view<K: KVStore>(
+    pub(crate) fn on_receive_view_info<K: KVStore>(
         &mut self, 
-        view: ViewNumber, 
-        leader: VerifyingKey,
-        next_leader: VerifyingKey,
+        view_info: ViewInfo,
         block_tree: &mut BlockTree<K>,
         app: &mut impl App<K>,
     ) {
@@ -85,7 +82,7 @@ impl<N: Network> HotStuff<N> {
     pub(crate) fn on_receive_msg<K: KVStore>(
         &mut self, 
         msg: HotStuffMessage,
-        origin: VerifyingKey,
+        origin: &VerifyingKey,
         block_tree: &mut BlockTree<K>,
         app: &mut impl App<K>,
     ) {
@@ -94,8 +91,8 @@ impl<N: Network> HotStuff<N> {
 
     fn on_receive_proposal<K: KVStore>(
         &mut self, 
-        proposal: Proposal, 
-        origin: VerifyingKey,
+        proposal: &Proposal, 
+        origin: &VerifyingKey,
         block_tree: &mut BlockTree<K>,
         app: &mut impl App<K>,
     ) {
@@ -104,8 +101,8 @@ impl<N: Network> HotStuff<N> {
 
     fn on_receive_nudge<K: KVStore>(
         &mut self, 
-        nudge: Nudge, 
-        origin: VerifyingKey,
+        nudge: &Nudge, 
+        origin: &VerifyingKey,
         block_tree: &mut BlockTree<K>,
     ) {
         todo!()
@@ -113,8 +110,8 @@ impl<N: Network> HotStuff<N> {
 
     fn on_receive_vote<K: KVStore>(
         &mut self, 
-        vote: Vote, 
-        origin: VerifyingKey,
+        vote: &Vote, 
+        origin: &VerifyingKey,
         block_tree: &mut BlockTree<K>,
     ) {
         todo!()
@@ -122,8 +119,8 @@ impl<N: Network> HotStuff<N> {
 
     fn on_receive_new_view<K: KVStore>(
         &mut self, 
-        new_view: NewView, 
-        origin: VerifyingKey,
+        new_view: &NewView, 
+        origin: &VerifyingKey,
         block_tree: &mut BlockTree<K>,
     ) {
         todo!()
@@ -138,13 +135,9 @@ pub(crate) struct HotStuffConfiguration {
     pub(crate) keypair: Keypair,
 }
 
-/// Internal state of the [HotStuff] protocol. Stores the current view and the current leader,
-/// for which the protocol should execute, as well as the [Vote] and [NewView] messages collected
+/// Internal state of the [HotStuff] protocol. Stores the [Vote] and [NewView] messages collected
 /// in the current view. This state should always be updated on entering a view.
 struct HotStuffState {
-    cur_view: ViewNumber,
-    cur_leader: VerifyingKey,
-    next_leader: VerifyingKey,
     vote_collector: VoteCollector,
     new_view_collector: NewViewCollector,
 }
@@ -154,14 +147,9 @@ impl HotStuffState {
     fn new(
         config: HotStuffConfiguration,
         view: ViewNumber,
-        leader: VerifyingKey,
-        next_leader: VerifyingKey,
         validator_set: ValidatorSet,
     ) -> Self {
         Self {
-            cur_view: view,
-            cur_leader: leader,
-            next_leader,
             vote_collector: VoteCollector::new(config.chain_id, view, validator_set.clone()),
             new_view_collector: NewViewCollector::new(validator_set),
         }

--- a/src/hotstuff/types.rs
+++ b/src/hotstuff/types.rs
@@ -49,7 +49,7 @@ impl QuorumCertificate {
                 .zip(validator_set.validators_and_powers())
             {
                 if let Some(signature) = signature {
-                    if let Ok(signature) = Signature::from_slice(&signature.get_bytes()) {
+                    if let Ok(signature) = Signature::from_slice(&signature.bytes()) {
                         if signer
                             .verify(
                                 &(self.chain_id, self.view, self.block, self.phase)

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -73,7 +73,7 @@ impl Logger for InsertBlockEvent {
                 "{}, {}, {}, {}",
                 INSERT_BLOCK,
                 secs_since_unix_epoch(insert_block_event.timestamp),
-                first_seven_base64_chars(&insert_block_event.block.hash.get_bytes()),
+                first_seven_base64_chars(&insert_block_event.block.hash.bytes()),
                 insert_block_event.block.height
             )
         };
@@ -84,7 +84,7 @@ impl Logger for InsertBlockEvent {
 impl Logger for CommitBlockEvent {
     fn get_logger() -> Box<dyn Fn(&Self) + Send> {
         let logger = |commit_block_event: &CommitBlockEvent| {
-            log::info!("{}, {}, {}", COMMIT_BLOCK, secs_since_unix_epoch(commit_block_event.timestamp), first_seven_base64_chars(&commit_block_event.block.get_bytes()))
+            log::info!("{}, {}, {}", COMMIT_BLOCK, secs_since_unix_epoch(commit_block_event.timestamp), first_seven_base64_chars(&commit_block_event.block.bytes()))
         };
         Box::new(logger)
     }
@@ -93,7 +93,7 @@ impl Logger for CommitBlockEvent {
 impl Logger for PruneBlockEvent {
     fn get_logger() -> Box<dyn Fn(&Self) + Send> {
         let logger = |prune_block_event: &PruneBlockEvent| {
-            log::info!("{}, {}, {}", PRUNE_BLOCK, secs_since_unix_epoch(prune_block_event.timestamp), first_seven_base64_chars(&prune_block_event.block.get_bytes()))
+            log::info!("{}, {}, {}", PRUNE_BLOCK, secs_since_unix_epoch(prune_block_event.timestamp), first_seven_base64_chars(&prune_block_event.block.bytes()))
         };
         Box::new(logger)
     }
@@ -106,7 +106,7 @@ impl Logger for UpdateHighestQCEvent {
                 "{}, {}, {}, {}, {:?}",
                 UPDATE_HIGHEST_QC,
                 secs_since_unix_epoch(update_highest_qc_event.timestamp),
-                first_seven_base64_chars(&update_highest_qc_event.highest_qc.block.get_bytes()),
+                first_seven_base64_chars(&update_highest_qc_event.highest_qc.block.bytes()),
                 update_highest_qc_event.highest_qc.view,
                 update_highest_qc_event.highest_qc.phase
             )
@@ -136,7 +136,7 @@ impl Logger for UpdateValidatorSetEvent {
                 "{}, {}, {}",
                 UPDATE_VALIDATOR_SET,
                 secs_since_unix_epoch(update_validator_set_event.timestamp),
-                first_seven_base64_chars(&update_validator_set_event.cause_block.get_bytes())
+                first_seven_base64_chars(&update_validator_set_event.cause_block.bytes())
             )
         };
         Box::new(logger)
@@ -150,7 +150,7 @@ impl Logger for ProposeEvent {
                 "{}, {}, {}, {}, {}",
                 PROPOSE,
                 secs_since_unix_epoch(propose_event.timestamp),
-                first_seven_base64_chars(&propose_event.proposal.block.hash.get_bytes()),
+                first_seven_base64_chars(&propose_event.proposal.block.hash.bytes()),
                 propose_event.proposal.block.height,
                 propose_event.proposal.view
             )
@@ -166,7 +166,7 @@ impl Logger for NudgeEvent {
                 "{}, {}, {}, {}, {:?}",
                 NUDGE,
                 secs_since_unix_epoch(nudge_event.timestamp),
-                first_seven_base64_chars(&nudge_event.nudge.justify.block.get_bytes()),
+                first_seven_base64_chars(&nudge_event.nudge.justify.block.bytes()),
                 nudge_event.nudge.view,
                 nudge_event.nudge.justify.phase
             )
@@ -182,7 +182,7 @@ impl Logger for VoteEvent {
                 "{}, {}, {}, {}, {:?}",
                 VOTE,
                 secs_since_unix_epoch(vote_event.timestamp),
-                first_seven_base64_chars(&vote_event.vote.block.get_bytes()),
+                first_seven_base64_chars(&vote_event.vote.block.bytes()),
                 vote_event.vote.view,
                 vote_event.vote.phase
             )
@@ -198,7 +198,7 @@ impl Logger for NewViewEvent {
                 "{}, {}, {}, {}, {:?}",
                 NEW_VIEW,
                 secs_since_unix_epoch(new_view_event.timestamp),
-                first_seven_base64_chars(&new_view_event.new_view.highest_qc.block.get_bytes()),
+                first_seven_base64_chars(&new_view_event.new_view.highest_qc.block.bytes()),
                 new_view_event.new_view.view,
                 new_view_event.new_view.highest_qc.phase
             )
@@ -215,7 +215,7 @@ impl Logger for ReceiveProposalEvent {
                 RECEIVE_PROPOSAL,
                 secs_since_unix_epoch(receive_proposal_event.timestamp),
                 first_seven_base64_chars(&receive_proposal_event.origin.to_bytes()),
-                first_seven_base64_chars(&receive_proposal_event.proposal.block.hash.get_bytes()),
+                first_seven_base64_chars(&receive_proposal_event.proposal.block.hash.bytes()),
                 receive_proposal_event.proposal.block.height
             )
         };
@@ -231,7 +231,7 @@ impl Logger for ReceiveNudgeEvent {
                 RECEIVE_NUDGE,
                 secs_since_unix_epoch(receive_nudge_event.timestamp),
                 first_seven_base64_chars(&receive_nudge_event.origin.to_bytes()),
-                first_seven_base64_chars(&receive_nudge_event.nudge.justify.block.get_bytes()),
+                first_seven_base64_chars(&receive_nudge_event.nudge.justify.block.bytes()),
                 receive_nudge_event.nudge.justify.phase
             )
         };
@@ -247,7 +247,7 @@ impl Logger for ReceiveVoteEvent {
                 RECEIVE_VOTE,
                 secs_since_unix_epoch(receive_vote_event.timestamp),
                 first_seven_base64_chars(&receive_vote_event.origin.to_bytes()),
-                first_seven_base64_chars(&receive_vote_event.vote.block.get_bytes()),
+                first_seven_base64_chars(&receive_vote_event.vote.block.bytes()),
                 receive_vote_event.vote.phase
             )
         };
@@ -263,7 +263,7 @@ impl Logger for ReceiveNewViewEvent {
                 RECEIVE_NEW_VIEW,
                 secs_since_unix_epoch(receive_new_view_event.timestamp),
                 first_seven_base64_chars(&receive_new_view_event.origin.to_bytes()),
-                first_seven_base64_chars(&receive_new_view_event.new_view.highest_qc.block.get_bytes()),
+                first_seven_base64_chars(&receive_new_view_event.new_view.highest_qc.block.bytes()),
                 receive_new_view_event.new_view.view,
                 receive_new_view_event.new_view.highest_qc.phase
             )
@@ -309,7 +309,7 @@ impl Logger for CollectQCEvent {
                 "{}, {}, {}, {}, {:?}",
                 COLLECT_QC,
                 secs_since_unix_epoch(collect_qc_event.timestamp),
-                first_seven_base64_chars(&collect_qc_event.quorum_certificate.block.get_bytes()),
+                first_seven_base64_chars(&collect_qc_event.quorum_certificate.block.bytes()),
                 collect_qc_event.quorum_certificate.view,
                 collect_qc_event.quorum_certificate.phase,
             )
@@ -360,7 +360,7 @@ impl Logger for SendSyncResponseEvent {
                 SEND_SYNC_RESPONSE,
                 secs_since_unix_epoch(send_sync_response_event.timestamp),
                 first_seven_base64_chars(&send_sync_response_event.peer.to_bytes()),
-                first_seven_base64_chars(&send_sync_response_event.highest_qc.block.get_bytes()),
+                first_seven_base64_chars(&send_sync_response_event.highest_qc.block.bytes()),
                 send_sync_response_event.blocks.len(),
             )  
         };

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -10,7 +10,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use ed25519_dalek::{Signature, VerifyingKey, Verifier};
 
-use crate::block_sync::messages::{BlockSyncMessage, BlockSyncTriggerMessage};
+use crate::block_sync::messages::{AdvertiseBlock, BlockSyncMessage, BlockSyncRequest, BlockSyncResponse, BlockSyncTriggerMessage};
 use crate::hotstuff::messages::HotStuffMessage;
 use crate::pacemaker::messages::PacemakerMessage;
 use crate::types::basic::SignatureBytes;
@@ -52,5 +52,38 @@ pub(crate) trait SignedMessage {
         )
         .is_ok()
     }
+}
 
+impl From<PacemakerMessage> for Message {
+    fn from(value: PacemakerMessage) -> Self {
+        Message::ProgressMessage(ProgressMessage::PacemakerMessage(value))
+    }
+}
+
+impl From<BlockSyncRequest> for Message {
+    fn from(value: BlockSyncRequest) -> Self {
+        Message::BlockSyncMessage(BlockSyncMessage::BlockSyncRequest(value))
+    }
+}
+
+impl From<BlockSyncResponse> for Message {
+    fn from(value: BlockSyncResponse) -> Self {
+        Message::BlockSyncMessage(BlockSyncMessage::BlockSyncResponse(value))
+    }
+}
+
+impl From<AdvertiseBlock> for Message {
+    fn from(value: AdvertiseBlock) -> Self {
+        Message::ProgressMessage(ProgressMessage::
+            BlockSyncTriggerMessage(BlockSyncTriggerMessage::
+                AdvertiseBlock(value)
+            )
+        )
+    }
+}
+
+impl From<HotStuffMessage> for Message {
+    fn from(value: HotStuffMessage) -> Self {
+        Message::ProgressMessage(ProgressMessage::HotStuffMessage(value))
+    }
 }

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -78,7 +78,7 @@ pub(crate) trait SignedMessage {
 
     // Verifies the correctness of the signature given the values that should be signed.
     fn is_correct(&self, pk:&VerifyingKey) -> bool {
-        let signature = Signature::from_bytes(&self.signature_bytes().get_bytes());
+        let signature = Signature::from_bytes(&self.signature_bytes().bytes());
         pk.verify(
             &self.message_bytes(),
             &signature,

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -265,8 +265,8 @@ impl ProgressMessageBuffer {
         
         // Try to cache the message.
         let bytes_requested = mem::size_of::<VerifyingKey>() as u64 + msg.size();
-        let new_buffer_size = self.buffer_size.get_int().checked_add(bytes_requested);
-        let buffer_will_be_overloaded = new_buffer_size.is_none() || new_buffer_size.unwrap() > self.buffer_capacity.get_int();
+        let new_buffer_size = self.buffer_size.int().checked_add(bytes_requested);
+        let buffer_will_be_overloaded = new_buffer_size.is_none() || new_buffer_size.unwrap() > self.buffer_capacity.int();
         let cache_message_if_buffer_will_be_overloaded = self.buffer.keys().max().is_none()
                                                                || self.buffer.keys().max().is_some_and(|max_view| msg.view() < *max_view);
 

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -11,17 +11,15 @@
 //! that collectively allow peers to exchange progress protocol and sync protocol messages.  
 
 use std::collections::{BTreeMap, VecDeque};
-use std::sync::mpsc::{Receiver, RecvTimeoutError, TryRecvError};
+use std::mem;
+use std::sync::mpsc::{self, Receiver, RecvTimeoutError, TryRecvError};
 use std::thread::{self, JoinHandle};
 use std::time::Instant;
 
 use ed25519_dalek::VerifyingKey;
 
-use crate::block_sync::messages::{BlockSyncRequest, BlockSyncResponse};
-use crate::hotstuff::messages::HotStuffMessage;
+use crate::block_sync::messages::{BlockSyncMessage, BlockSyncRequest, BlockSyncResponse};
 use crate::messages::*;
-use crate::pacemaker::messages::PacemakerMessage;
-use crate::pacemaker::protocol::ViewInfo;
 use crate::types::basic::{BufferSize, ChainID, ViewNumber};
 use crate::types::validators::{ValidatorSet, ValidatorSetUpdates};
 
@@ -43,7 +41,7 @@ pub trait Network: Clone + Send {
 }
 
 /// Spawn the poller thread, which polls the [Network] for messages and distributes them into receivers for:
-/// 1. Progress messages (processed by the [Algorithm][crate::algorithm::Algorithm]), and
+/// 1. Progress messages (processed by the [Algorithm][crate::algorithm::Algorithm]'s execute loop), and
 /// 2. Block sync requests (processed by [BlockSyncServer][crate::block_sync::server::BlockSyncServer]), and 
 /// 3. Block sync responses (processed by [BlockSyncClient][crate::block_sync::client::BlockSyncClient]).
 pub(crate) fn start_polling<N: Network + 'static>(
@@ -55,7 +53,43 @@ pub(crate) fn start_polling<N: Network + 'static>(
     Receiver<(VerifyingKey, BlockSyncRequest)>,
     Receiver<(VerifyingKey, BlockSyncResponse)>,
 ) {
-    todo!()
+    let (to_progress_msg_receiver, progress_msg_receiver) = mpsc::channel();
+    let (to_sync_request_receiver, sync_request_receiver) = mpsc::channel();
+    let (to_sync_response_receiver, sync_response_receiver) = mpsc::channel();
+
+    let poller_thread = thread::spawn(move || loop {
+        match shutdown_signal.try_recv() {
+            Ok(()) => return,
+            Err(TryRecvError::Empty) => (),
+            Err(TryRecvError::Disconnected) => {
+                panic!("Poller thread disconnected from main thread")
+            }
+        }
+
+        if let Some((origin, msg)) = network.recv() {
+            match msg {
+                Message::ProgressMessage(p_msg) => {
+                    let _ = to_progress_msg_receiver.send((origin, p_msg));
+                }
+                Message::BlockSyncMessage(s_msg) => match s_msg {
+                    BlockSyncMessage::BlockSyncRequest(s_req) => {
+                        let _ = to_sync_request_receiver.send((origin, s_req));
+                    }
+                    BlockSyncMessage::BlockSyncResponse(s_res) => {
+                        let _ = to_sync_response_receiver.send((origin, s_res));
+                    }
+                },
+            }
+        } else {
+            thread::yield_now()
+        }
+    });
+    (
+        poller_thread,
+        progress_msg_receiver,
+        sync_request_receiver,
+        sync_response_receiver,
+    )
 }
 
 /// Handle for sending and broadcasting messages to the [Network].
@@ -99,7 +133,7 @@ impl<N: Network> ValidatorSetUpdateHandle<N> {
 /// A receiving end for progress messages. Performs pre-processing of the received messages,
 /// returning the messages immediately or storing them in the buffer.
 ///
-/// All messages must match the chain id to be accepted.
+/// All messages must match the chain id passed to the receiver to be accepted.
 ///
 /// ### HotStuff Messages
 /// This type's recv method only returns hotstuff messages for the current view, and caches messages from
@@ -117,59 +151,103 @@ impl<N: Network> ValidatorSetUpdateHandle<N> {
 /// ### Buffer management
 /// If a message buffer grows beyond its maximum capacity, some highest-viewed messages might be removed 
 /// from the buffer to make space for the new message.
-pub(crate) struct ProgressMessageStub<N: Network> {
-    network: N,
+pub(crate) struct ProgressMessageStub {
     receiver: Receiver<(VerifyingKey, ProgressMessage)>,
-    hotstuff_msg_buffer: MessageBuffer<HotStuffMessage>,
-    pacemaker_msg_buffer: MessageBuffer<PacemakerMessage>,
+    msg_buffer: ProgressMessageBuffer,
 }
 
-impl<N: Network> ProgressMessageStub<N> {
+impl ProgressMessageStub {
+    /// Create a fresh [ProgressMessageStub] with a given receiver end and buffer capacity.
     pub(crate) fn new(
-        network: N,
         receiver: Receiver<(VerifyingKey, ProgressMessage)>,
         msg_buffer_capacity: BufferSize,
-    ) -> ProgressMessageStub<N> {
-        let hotstuff_msg_buffer: MessageBuffer<HotStuffMessage> = MessageBuffer::new(msg_buffer_capacity);
-        let pacemaker_msg_buffer: MessageBuffer<PacemakerMessage> = MessageBuffer::new(msg_buffer_capacity);
+    ) -> ProgressMessageStub {
+        let msg_buffer: ProgressMessageBuffer = ProgressMessageBuffer::new(msg_buffer_capacity);
         Self {
-            network,
             receiver,
-            hotstuff_msg_buffer,
-            pacemaker_msg_buffer,
+            msg_buffer,
         }
     }
 
-    /// Receive a message matching the given chain id, and view >= current view.
+    /// Receive a message matching the given chain id, and view >= current view (if any).
     /// Cache and/or return immediately, depending on the message type.
     /// Messages older than current view are dropped immediately.
     /// [BlockSyncTriggerMessage][crate::block_sync::messages::BlockSyncTriggerMessage] 
-    /// messages are an exception since they do not have a view,
-    /// and they are returned immediately, as long as the chain id is correct.
+    /// messages do not have a view, and so they are returned immediately..
     pub(crate) fn recv(
         &mut self,
         chain_id: ChainID,
-        view: ViewNumber,
+        cur_view: ViewNumber,
         deadline: Instant,
     ) -> Result<(VerifyingKey, ProgressMessage), ProgressMessageReceiveError> {
-         todo!()
+        // Clear buffer of messages with views lower than the current one.
+        self.msg_buffer.remove_expired_msgs(cur_view);
+
+        // Try to get buffered messages for the current view.
+        if let Some((sender, msg)) = self.msg_buffer.get_msg(&cur_view) {
+            return Ok((sender, msg))
+        }
+
+        // Try to get messages from the poller.
+        while Instant::now() < deadline {
+            match self.receiver.recv_timeout(deadline - Instant::now()) {
+                Ok((sender, msg)) => {
+
+                    if msg.chain_id() != chain_id {
+                        continue;
+                    }
+
+                    // If the message is for a future view then cache it.
+                    if msg.view().is_some_and(|view| view > cur_view) {
+                        match msg.clone() {
+                            ProgressMessage::HotStuffMessage(msg) => {self.msg_buffer.insert(msg, sender);},
+                            ProgressMessage::PacemakerMessage(msg) => {self.msg_buffer.insert(msg, sender);},
+                            _ => (),
+                        }
+                    }
+                    
+                    // Return the message if either:
+                    // 1. It is a HotStuff message for the current view, or
+                    // 2. If it is a Pacemaker message for the current view or a future view, or
+                    // 3. If it is a BlockSyncTrigger message.
+                    let return_msg = match &msg {
+                        ProgressMessage::HotStuffMessage(hotstuff_msg) => hotstuff_msg.view() == cur_view,
+                        ProgressMessage::PacemakerMessage(pacemaker_msg) => pacemaker_msg.view() >= cur_view,
+                        ProgressMessage::BlockSyncTriggerMessage(_) => true,
+                    };
+
+                    if return_msg {
+                        return Ok((sender, msg))
+                    }
+
+                },
+                Err(RecvTimeoutError::Timeout) => thread::yield_now(),
+                Err(RecvTimeoutError::Disconnected) => return Err(ProgressMessageReceiveError::Disconnected),
+            }
+        }
+
+        Err(ProgressMessageReceiveError::Timeout)
     }
 
 }
 
+#[derive(Debug)]
 pub(crate) enum ProgressMessageReceiveError {
     Timeout,
+    Disconnected,
 }
 
-struct FailedToInsert;
-
-struct MessageBuffer<M> {
+/// Message buffer intended for storing received [ProgressMessage]s for future views.
+/// Its size is bounded by its capacity, and when the capacity is reached messages
+/// for highest views may be removed.
+struct ProgressMessageBuffer {
     buffer_capacity: BufferSize,
-    buffer: BTreeMap<ViewNumber, VecDeque<(VerifyingKey, M)>>,
+    buffer: BTreeMap<ViewNumber, VecDeque<(VerifyingKey, ProgressMessage)>>,
     buffer_size: BufferSize,
 }
 
-impl<M> MessageBuffer<M> {
+impl ProgressMessageBuffer {
+    /// Create an empty message buffer.
     fn new(buffer_capacity: BufferSize) -> Self {
         Self {
             buffer_capacity,
@@ -182,52 +260,141 @@ impl<M> MessageBuffer<M> {
     /// In case caching the message makes the buffer grow beyond its capacity, this function either:
     /// 1. If the message has the highest view among the views of messages currently in the buffer, then the message is dropped, or
     /// 2. Otherwise, just enough highest-viewed messages are removed from the buffer to make space for the new message.
-    fn insert(msg: M, origin: VerifyingKey) -> Result<(), FailedToInsert> {
-        todo!()
+    /// Returns whether the message was successfully inserted into the buffer.
+    fn insert<M: Into<ProgressMessage> + Cacheable>(&mut self, msg: M, sender: VerifyingKey) -> bool {
+        
+        // Try to cache the message.
+        let bytes_requested = mem::size_of::<VerifyingKey>() as u64 + msg.size();
+        let new_buffer_size = self.buffer_size.get_int().checked_add(bytes_requested);
+        let buffer_will_be_overloaded = new_buffer_size.is_none() || new_buffer_size.unwrap() > self.buffer_capacity.get_int();
+        let cache_message_if_buffer_will_be_overloaded = self.buffer.keys().max().is_none()
+                                                               || self.buffer.keys().max().is_some_and(|max_view| msg.view() < *max_view);
+
+        // We only need to make space in the buffer if:
+        // (1) It will be overloaded after storing the message, and 
+        // (2) We want to store this message in the buffer, i.e., if the message's view is lower than that of the highest-viewed 
+        //     message stored in the buffer
+        // Otherwise we ignore the message to avoid overloading the buffer.
+        if buffer_will_be_overloaded && cache_message_if_buffer_will_be_overloaded {
+            self.remove_highest_viewed_msgs(bytes_requested);
+        };
+
+        // We only store the message in the buffer if either:
+        // (1) There is no risk of overloading the buffer upon storing this message, or
+        // (2) The buffer might be overloaded, but we have already made space for the new message.
+        if !buffer_will_be_overloaded || (buffer_will_be_overloaded && cache_message_if_buffer_will_be_overloaded) {
+            let msg_queue = 
+                if let Some(msg_queue) = self.buffer.get_mut(&msg.view())
+                {
+                    msg_queue
+                } else {
+                    self.buffer.insert(msg.view(), VecDeque::new());
+                    // Safety: this key has just been inserted.
+                    self.buffer.get_mut(&msg.view()).unwrap()
+                };
+
+            self.buffer_size += bytes_requested;
+            msg_queue.push_back((sender, msg.into()));
+            return true
+        };
+        false
+    }
+
+    /// If there are messages for this view in the buffer, remove and return the message at the front of the queue.
+    fn get_msg(&mut self, view: &ViewNumber) -> Option<(VerifyingKey, ProgressMessage)> {
+        self.buffer.get_mut(view).map(|msg_queue| msg_queue.pop_front()).flatten()
     }
 
     /// Given the number of bytes that need to be removed, removes just enough highest-viewed messages
     /// to free up (at least) the required number of bytes in the buffer.
     fn remove_highest_viewed_msgs(&mut self, bytes_to_remove: u64) {
-        todo!()
+        let verifying_key_size = mem::size_of::<VerifyingKey>() as u64;
+        
+        let mut bytes_removed = 0;
+        let mut views_removed = Vec::new();
+        let mut msg_queues_iter = self.buffer.iter_mut().rev();
+
+        // Removes messages from the message buffer until the required number of bytes is freed.
+        while bytes_removed < bytes_to_remove {
+            // Take the message queue for the next highest view, and remove its messages until the required number of bytes is freed.
+            if let Some((view, msg_queue)) = msg_queues_iter.next() {
+                let removals = 
+                    msg_queue.iter().rev()
+                    .take_while(|(_, msg)| 
+                        {
+                            if bytes_removed < bytes_to_remove {
+                                bytes_removed += msg.size() + verifying_key_size;
+                                true
+                            } else {
+                                false
+                            }
+                        }
+                    )
+                    .count() as u64;
+                let _ = (0..removals).into_iter().for_each(|_| { let _ = msg_queue.pop_back(); });
+                if msg_queue.is_empty() {
+                    views_removed.push(*view)
+                }
+            } else {
+                break
+            }
+        };
+
+        self.buffer_size -= bytes_removed;
+        
+        // If some views in the message buffer have lost all messages as a result of the removal,
+        // then also remove their corresponding keys from the buffer.
+        views_removed.iter().for_each(|view| {let _ = self.buffer.remove(view);});
+    }
+
+    /// Remove all messages for views less than the current view.
+    fn remove_expired_msgs(&mut self, cur_view: ViewNumber) {
+        self.buffer = self.buffer.split_off(&cur_view)
     }
 }
 
 /// A receiving end for sync responses.
 /// The [BlockSyncClientStub::recv_response] method returns the received response.
-pub(crate) struct BlockSyncClientStub<N: Network> {
-    network: N,
+pub(crate) struct BlockSyncClientStub {
     responses: Receiver<(VerifyingKey, BlockSyncResponse)>,
 }
 
-impl<N: Network> BlockSyncClientStub<N> {
+impl BlockSyncClientStub {
     pub(crate) fn new(
-        network: N,
         responses: Receiver<(VerifyingKey, BlockSyncResponse)>,
-    ) -> BlockSyncClientStub<N> {
-        BlockSyncClientStub { network, responses }
+    ) -> BlockSyncClientStub {
+        BlockSyncClientStub { responses }
     }
 
+    /// Receive a [BlockSyncResponse] from a given peer.
+    /// Waits for the response until the deadline is reached, and
+    /// if no response is received it returns [BlockSyncResponseReceiveError::Timeout].
     pub(crate) fn recv_response(
         &self,
         peer: VerifyingKey,
         deadline: Instant,
-    ) -> Option<BlockSyncResponse> {
+    ) -> Result<BlockSyncResponse, BlockSyncResponseReceiveError> {
         while Instant::now() < deadline {
             match self.responses.recv_timeout(deadline - Instant::now()) {
                 Ok((sender, sync_response)) => {
                     if sender == peer {
-                        return Some(sync_response);
+                        return Ok(sync_response);
                     }
                 }
                 Err(RecvTimeoutError::Timeout) => thread::yield_now(),
-                Err(RecvTimeoutError::Disconnected) => panic!(),
+                Err(RecvTimeoutError::Disconnected) => return Err(BlockSyncResponseReceiveError::Disconnected),
             }
         }
 
-        None
+        Err(BlockSyncResponseReceiveError::Timeout)
     }
 
+}
+
+#[derive(Debug)]
+pub enum BlockSyncResponseReceiveError {
+    Disconnected,
+    Timeout,
 }
 
 /// A receiving end for sync requests. 
@@ -245,13 +412,20 @@ impl<N: Network> BlockSyncServerStub<N> {
         BlockSyncServerStub { network, requests }
     }
 
-    pub(crate) fn recv_request(&self) -> Option<(VerifyingKey, BlockSyncRequest)> {
+    /// Receive a [BlockSyncRequest] if available, else return [BlockSyncRequestReceiveError::NotAvailable].
+    pub(crate) fn recv_request(&self) -> Result<(VerifyingKey, BlockSyncRequest), BlockSyncRequestReceiveError> {
         match self.requests.try_recv() {
-            Ok((origin, request)) => Some((origin, request)),
+            Ok((origin, request)) => Ok((origin, request)),
             // Safety: the sync server thread (the only caller of this function) shuts down before the poller thread
             // (the sender side of this channel), so we will never be disconnected at this point.
-            Err(TryRecvError::Disconnected) => panic!(),
-            Err(TryRecvError::Empty) => None,
+            Err(TryRecvError::Disconnected) => Err(BlockSyncRequestReceiveError::Disconnected),
+            Err(TryRecvError::Empty) => Err(BlockSyncRequestReceiveError::NotAvailable),
         }
     }
+}
+
+#[derive(Debug)]
+pub enum BlockSyncRequestReceiveError {
+    Disconnected,
+    NotAvailable,
 }

--- a/src/networking.rs
+++ b/src/networking.rs
@@ -21,6 +21,7 @@ use crate::block_sync::messages::{BlockSyncRequest, BlockSyncResponse};
 use crate::hotstuff::messages::HotStuffMessage;
 use crate::messages::*;
 use crate::pacemaker::messages::PacemakerMessage;
+use crate::pacemaker::protocol::ViewInfo;
 use crate::types::basic::{BufferSize, ChainID, ViewNumber};
 use crate::types::validators::{ValidatorSet, ValidatorSetUpdates};
 
@@ -148,7 +149,7 @@ impl<N: Network> ProgressMessageStub<N> {
     pub(crate) fn recv(
         &mut self,
         chain_id: ChainID,
-        cur_view: ViewNumber,
+        view: ViewNumber,
         deadline: Instant,
     ) -> Result<(VerifyingKey, ProgressMessage), ProgressMessageReceiveError> {
          todo!()

--- a/src/pacemaker/messages.rs
+++ b/src/pacemaker/messages.rs
@@ -26,10 +26,10 @@ pub enum PacemakerMessage {
 impl PacemakerMessage {
 
     pub(crate) fn timeout_vote(
-        me: Keypair,
+        me: &Keypair,
         chain_id: ChainID,
         view: ViewNumber,
-        highest_tc: TimeoutCertificate,
+        highest_tc: Option<TimeoutCertificate>,
     ) -> PacemakerMessage {
         let message = &(chain_id, view)
             .try_to_vec()
@@ -71,18 +71,12 @@ impl PacemakerMessage {
 
 }
 
-impl Into<Message> for PacemakerMessage {
-    fn into(self) -> Message {
-        Message::ProgressMessage(ProgressMessage::PacemakerMessage(self))
-    }
-}
-
 #[derive(Clone, BorshSerialize, BorshDeserialize)]
 pub struct TimeoutVote {
     pub chain_id: ChainID,
     pub view: ViewNumber,
     pub signature: SignatureBytes,
-    pub highest_tc: TimeoutCertificate,
+    pub highest_tc: Option<TimeoutCertificate>,
 }
 
 impl SignedMessage for TimeoutVote {

--- a/src/pacemaker/messages.rs
+++ b/src/pacemaker/messages.rs
@@ -9,7 +9,7 @@ use std::mem;
 use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::hotstuff::types::QuorumCertificate;
-use crate::messages::{Message, ProgressMessage, SignedMessage};
+use crate::messages::{Cacheable, Message, ProgressMessage, SignedMessage};
 use crate::types::{
     basic::*, 
     keypair::*,
@@ -69,6 +69,22 @@ impl PacemakerMessage {
         }
     }
 
+}
+
+impl Cacheable for PacemakerMessage {
+    fn size(&self) -> u64 {
+        self.size()
+    }
+
+    fn view(&self) -> ViewNumber {
+        self.view()
+    }
+}
+
+impl Into<ProgressMessage> for PacemakerMessage {
+    fn into(self) -> ProgressMessage {
+        ProgressMessage::PacemakerMessage(self)
+    }
 }
 
 #[derive(Clone, BorshSerialize, BorshDeserialize)]

--- a/src/pacemaker/protocol.rs
+++ b/src/pacemaker/protocol.rs
@@ -306,13 +306,13 @@ impl PacemakerState {
         self.timeouts = self.timeouts.split_off(&start_view);
 
         let epoch = epoch(start_view, config.epoch_length);
-        let epoch_view = epoch * config.epoch_length.get_int() as u64;
+        let epoch_view = epoch * config.epoch_length.int() as u64;
 
         let start_time = Instant::now();
 
         // Add timeouts for all remaining views in the epoch of start_view.
-        for view in start_view.get_int()..=epoch_view {
-            let time_to_view_deadline = Duration::from_secs(config.max_view_time.as_secs()*(view - start_view.get_int() + 1));
+        for view in start_view.int()..=epoch_view {
+            let time_to_view_deadline = Duration::from_secs(config.max_view_time.as_secs()*(view - start_view.int() + 1));
             self.timeouts.insert(ViewNumber::new(view), start_time + time_to_view_deadline);
         }
     }
@@ -321,13 +321,13 @@ impl PacemakerState {
         let mut timeouts = BTreeMap::new();
 
         let epoch = epoch(start_view, config.epoch_length);
-        let epoch_view = epoch * config.epoch_length.get_int() as u64;
+        let epoch_view = epoch * config.epoch_length.int() as u64;
 
         let start_time = Instant::now();
 
         // Add timeouts for all remaining views in the epoch of start_view.
-        for view in start_view.get_int()..=epoch_view {
-            let time_to_view_deadline = Duration::from_secs(config.max_view_time.as_secs()*(view - start_view.get_int() + 1));
+        for view in start_view.int()..=epoch_view {
+            let time_to_view_deadline = Duration::from_secs(config.max_view_time.as_secs()*(view - start_view.int() + 1));
             timeouts.insert(ViewNumber::new(view), start_time + time_to_view_deadline);
         }
 
@@ -407,10 +407,10 @@ fn select_leader(
     // Total number of validators.
     let n = validator_set.len();
     // Index in the abstract array.
-    let index = view.get_int() % (p_total.get_int() as u64);
+    let index = view.int() % (p_total.int() as u64);
     // Max. power among the validators.
     let p_max = 
-        validator_set.validators_and_powers().iter().map(|(_, power)| power.get_int()).max().expect("The validator set cannot be empty!").clone();
+        validator_set.validators_and_powers().iter().map(|(_, power)| power.int()).max().expect("The validator set cannot be empty!").clone();
 
     let mut counter = 0;
 
@@ -418,7 +418,7 @@ fn select_leader(
     for threshold in 1..p_max {
         for k in 0..(n-1) {
             let validator = validator_set.validators().nth(k).unwrap();
-            if validator_set.power(validator).unwrap().get_int() >= threshold {
+            if validator_set.power(validator).unwrap().int() >= threshold {
                 if counter == index {
                     return *validator;
                 }
@@ -432,9 +432,9 @@ fn select_leader(
 }
 
 fn is_epoch_view(view: ViewNumber, epoch_length: EpochLength) -> bool {
-    view.get_int() % (epoch_length.get_int() as u64) == 0
+    view.int() % (epoch_length.int() as u64) == 0
 }
 
 fn epoch(view: ViewNumber, epoch_length: EpochLength) -> u64 {
-    view.get_int().div_ceil(epoch_length.get_int() as u64)
+    view.int().div_ceil(epoch_length.int() as u64)
 }

--- a/src/pacemaker/protocol.rs
+++ b/src/pacemaker/protocol.rs
@@ -238,7 +238,8 @@ impl<N: Network> Pacemaker<N> {
     /// Update the current view to the given next view. This may involve setting timeouts for the views
     /// of a new epoch, in case the next view is in a future epoch.
     /// Note: this method, by being the unique method used to update the pacemaker [ViewInfo],
-    /// and checking if the next view is greater than the current view, guarantees monotonicity.
+    /// and checking if the next view is greater than the current view, guarantees monotonically
+    /// increasing views.
     fn update_view<K: KVStore>(
         &mut self, 
         cur_view: ViewNumber, 

--- a/src/pacemaker/types.rs
+++ b/src/pacemaker/types.rs
@@ -41,7 +41,7 @@ impl TimeoutCertificate {
                 .zip(validator_set.validators_and_powers())
             {
                 if let Some(signature) = signature {
-                    if let Ok(signature) = Signature::from_slice(&signature.get_bytes()) {
+                    if let Ok(signature) = Signature::from_slice(&signature.bytes()) {
                         if signer
                             .verify(
                                 &(self.chain_id, self.view)

--- a/src/state.rs
+++ b/src/state.rs
@@ -625,7 +625,7 @@ impl<W: WriteBatch> BlockTreeWriteBatch<W> {
     /* ↓↓↓ Block ↓↓↓  */
 
     pub fn set_block(&mut self, block: &Block) {
-        let block_prefix = combine(&BLOCKS, &block.hash.get_bytes());
+        let block_prefix = combine(&BLOCKS, &block.hash.bytes());
 
         self.0.set(
             &combine(&block_prefix, &BLOCK_HEIGHT),
@@ -648,12 +648,12 @@ impl<W: WriteBatch> BlockTreeWriteBatch<W> {
         let block_data_prefix = combine(&block_prefix, &BLOCK_DATA);
         for (i, datum) in block.data.iter().enumerate() {
             let datum_key = combine(&block_data_prefix, &(i as u32).try_to_vec().unwrap());
-            self.0.set(&datum_key, datum.get_bytes());
+            self.0.set(&datum_key, datum.bytes());
         }
     }
 
     pub fn delete_block(&mut self, block: &CryptoHash, data_len: DataLen) {
-        let block_prefix = combine(&BLOCKS, &block.get_bytes());
+        let block_prefix = combine(&BLOCKS, &block.bytes());
 
         self.0.delete(&combine(&block_prefix, &BLOCK_HEIGHT));
         self.0.delete(&combine(&block_prefix, &BLOCK_JUSTIFY));
@@ -661,7 +661,7 @@ impl<W: WriteBatch> BlockTreeWriteBatch<W> {
         self.0.delete(&combine(&block_prefix, &BLOCK_DATA_LEN));
 
         let block_data_prefix = combine(&block_prefix, &BLOCK_DATA);
-        for i in 0..data_len.get_int() {
+        for i in 0..data_len.int() {
             let datum_key = combine(&block_data_prefix, &i.try_to_vec().unwrap());
             self.0.delete(&datum_key);
         }
@@ -680,13 +680,13 @@ impl<W: WriteBatch> BlockTreeWriteBatch<W> {
 
     pub fn set_children(&mut self, block: &CryptoHash, children: &ChildrenList) {
         self.0.set(
-            &combine(&BLOCK_TO_CHILDREN, &block.get_bytes()),
+            &combine(&BLOCK_TO_CHILDREN, &block.bytes()),
             &children.try_to_vec().unwrap(),
         );
     }
 
     pub fn delete_children(&mut self, block: &CryptoHash) {
-        self.0.delete(&combine(&BLOCK_TO_CHILDREN, &block.get_bytes()));
+        self.0.delete(&combine(&BLOCK_TO_CHILDREN, &block.bytes()));
     }
 
     /* ↓↓↓ Committed App State ↓↓↓ */
@@ -707,7 +707,7 @@ impl<W: WriteBatch> BlockTreeWriteBatch<W> {
         app_state_updates: &AppStateUpdates,
     ) {
         self.0.set(
-            &combine(&PENDING_APP_STATE_UPDATES, &block.get_bytes()),
+            &combine(&PENDING_APP_STATE_UPDATES, &block.bytes()),
             &app_state_updates.try_to_vec().unwrap(),
         );
     }
@@ -723,7 +723,7 @@ impl<W: WriteBatch> BlockTreeWriteBatch<W> {
     }
 
     pub fn delete_pending_app_state_updates(&mut self, block: &CryptoHash) {
-        self.0.delete(&combine(&PENDING_APP_STATE_UPDATES, &block.get_bytes()));
+        self.0.delete(&combine(&PENDING_APP_STATE_UPDATES, &block.bytes()));
     }
 
     /* ↓↓↓ Commmitted Validator Set */
@@ -745,14 +745,14 @@ impl<W: WriteBatch> BlockTreeWriteBatch<W> {
     ) {
         let validator_set_updates_bytes: ValidatorSetUpdatesBytes = validator_set_updates.into();
         self.0.set(
-            &combine(&PENDING_VALIDATOR_SET_UPDATES, &block.get_bytes()),
+            &combine(&PENDING_VALIDATOR_SET_UPDATES, &block.bytes()),
             &validator_set_updates_bytes.try_to_vec().unwrap(),
         )
     }
 
     pub fn delete_pending_validator_set_updates(&mut self, block: &CryptoHash) {
         self.0
-            .delete(&combine(&PENDING_VALIDATOR_SET_UPDATES, &block.get_bytes()))
+            .delete(&combine(&PENDING_VALIDATOR_SET_UPDATES, &block.bytes()))
     }
 
     /* ↓↓↓ Locked View ↓↓↓ */
@@ -947,7 +947,7 @@ re_export_getters_from_block_tree_and_block_tree_snapshot!(
         }
 
         fn block_height(&self, block: &CryptoHash) -> Option<BlockHeight> {
-            let block_key = combine(&BLOCKS, &block.get_bytes());
+            let block_key = combine(&BLOCKS, &block.bytes());
             let block_height_key = combine(&block_key, &BLOCK_HEIGHT);
             let block_height = {
                 let bs = self.get(&block_height_key)?;
@@ -959,7 +959,7 @@ re_export_getters_from_block_tree_and_block_tree_snapshot!(
         fn block_justify(&self, block: &CryptoHash) -> Option<QuorumCertificate> {
             Some(
                 QuorumCertificate::deserialize(
-                    &mut &*self.get(&combine(&BLOCKS, &combine(&block.get_bytes(), &BLOCK_JUSTIFY)))?,
+                    &mut &*self.get(&combine(&BLOCKS, &combine(&block.bytes(), &BLOCK_JUSTIFY)))?,
                 )
                 .unwrap(),
             )
@@ -968,7 +968,7 @@ re_export_getters_from_block_tree_and_block_tree_snapshot!(
         fn block_data_hash(&self, block: &CryptoHash) -> Option<CryptoHash> {
             Some(
                 CryptoHash::deserialize(
-                    &mut &*self.get(&combine(&BLOCKS, &combine(&block.get_bytes(), &BLOCK_DATA_HASH)))?,
+                    &mut &*self.get(&combine(&BLOCKS, &combine(&block.bytes(), &BLOCK_DATA_HASH)))?,
                 )
                 .unwrap(),
             )
@@ -977,7 +977,7 @@ re_export_getters_from_block_tree_and_block_tree_snapshot!(
         fn block_data_len(&self, block: &CryptoHash) -> Option<DataLen> {
             Some(
                 DataLen::deserialize(
-                    &mut &*self.get(&combine(&BLOCKS, &combine(&block.get_bytes(), &BLOCK_DATA_LEN)))?,
+                    &mut &*self.get(&combine(&BLOCKS, &combine(&block.bytes(), &BLOCK_DATA_LEN)))?,
                 )
                 .unwrap(),
             )
@@ -985,7 +985,7 @@ re_export_getters_from_block_tree_and_block_tree_snapshot!(
 
         fn block_data(&self, block: &CryptoHash) -> Option<Data> {
             let data_len = self.block_data_len(block)?;
-            let data = (0..data_len.get_int())
+            let data = (0..data_len.int())
                 .map(|i| self.block_datum(block, i).unwrap())
                 .collect();
 
@@ -993,7 +993,7 @@ re_export_getters_from_block_tree_and_block_tree_snapshot!(
         }
 
         fn block_datum(&self, block: &CryptoHash, datum_index: u32) -> Option<Datum> {
-            let block_data_prefix = combine(&BLOCKS, &combine(&block.get_bytes(), &BLOCK_DATA));
+            let block_data_prefix = combine(&BLOCKS, &combine(&block.bytes(), &BLOCK_DATA));
             self.get(&combine(
                 &block_data_prefix,
                 &datum_index.try_to_vec().unwrap(),
@@ -1017,7 +1017,7 @@ re_export_getters_from_block_tree_and_block_tree_snapshot!(
 
         fn children(&self, block: &CryptoHash) -> Option<ChildrenList> {
             Some(
-                ChildrenList::deserialize(&mut &*self.get(&combine(&BLOCK_TO_CHILDREN, &block.get_bytes()))?)
+                ChildrenList::deserialize(&mut &*self.get(&combine(&BLOCK_TO_CHILDREN, &block.bytes()))?)
                     .unwrap(),
             )
         }
@@ -1033,7 +1033,7 @@ re_export_getters_from_block_tree_and_block_tree_snapshot!(
         fn pending_app_state_updates(&self, block: &CryptoHash) -> Option<AppStateUpdates> {
             Some(
                 AppStateUpdates::deserialize(
-                    &mut &*self.get(&combine(&PENDING_APP_STATE_UPDATES, &block.get_bytes()))?,
+                    &mut &*self.get(&combine(&PENDING_APP_STATE_UPDATES, &block.bytes()))?,
                 )
                 .unwrap(),
             )
@@ -1049,7 +1049,7 @@ re_export_getters_from_block_tree_and_block_tree_snapshot!(
         /* ↓↓↓ Pending Validator Set Updates */
 
         fn pending_validator_set_updates(&self, block: &CryptoHash) -> Option<ValidatorSetUpdates> {
-            let validator_set_updates_bytes = ValidatorSetUpdatesBytes::deserialize(&mut &*self.get(&combine(&PENDING_VALIDATOR_SET_UPDATES, &block.get_bytes()))?,).unwrap();
+            let validator_set_updates_bytes = ValidatorSetUpdatesBytes::deserialize(&mut &*self.get(&combine(&PENDING_VALIDATOR_SET_UPDATES, &block.bytes()))?,).unwrap();
             Some(ValidatorSetUpdates::try_from(validator_set_updates_bytes).unwrap())
         }
 

--- a/src/types/basic.rs
+++ b/src/types/basic.rs
@@ -27,7 +27,7 @@ impl ChainID {
         Self(int)
     }
 
-    pub const fn get_int(&self) -> u64 {
+    pub const fn int(&self) -> u64 {
         self.0
     }
 }

--- a/src/types/basic.rs
+++ b/src/types/basic.rs
@@ -41,7 +41,7 @@ impl BlockHeight {
         Self(int)
     }
 
-    pub const fn get_int(&self) -> u64 {
+    pub const fn int(&self) -> u64 {
         self.0
     }
 
@@ -71,7 +71,7 @@ impl ChildrenList {
         Self(blocks)
     }
 
-    pub const fn get_vec(&self) -> &Vec<CryptoHash> {
+    pub const fn vec(&self) -> &Vec<CryptoHash> {
         &self.0
     }
 
@@ -94,7 +94,7 @@ impl CryptoHash {
         Self(bytes)
     }
 
-    pub const fn get_bytes(&self) -> [u8; 32] {
+    pub const fn bytes(&self) -> [u8; 32] {
         self.0
     }
 }
@@ -108,7 +108,7 @@ impl Data {
         Self(datum_vec)
     }
 
-    pub const fn get_vec(&self) -> &Vec<Datum> {
+    pub const fn vec(&self) -> &Vec<Datum> {
         &self.0
     }
 
@@ -126,7 +126,7 @@ impl Data {
 pub struct DataLen(u32);
 
 impl DataLen {
-    pub const fn get_int(&self) -> u32 {
+    pub const fn int(&self) -> u32 {
         self.0
     }
 }
@@ -140,7 +140,7 @@ impl Datum {
         Self(bytes)
     }
 
-    pub const fn get_bytes(&self) -> &Vec<u8> {
+    pub const fn bytes(&self) -> &Vec<u8> {
         &self.0
     }
 }
@@ -150,7 +150,7 @@ impl Datum {
 pub struct Power(u64);
 
 impl Power {
-    pub const fn get_int(&self) -> u64 {
+    pub const fn int(&self) -> u64 {
         self.0
     }
 }
@@ -164,7 +164,7 @@ impl TotalPower {
         Self(int)
     }
 
-    pub const fn get_int(&self) -> u128 {
+    pub const fn int(&self) -> u128 {
         self.0
     }
 }
@@ -184,7 +184,7 @@ impl SignatureBytes {
         Self(bytes)
     }
 
-    pub const fn get_bytes(&self) -> [u8; 64] {
+    pub const fn bytes(&self) -> [u8; 64] {
         self.0
     }
 }
@@ -205,7 +205,7 @@ impl SignatureSet {
         Self(vec![None; len])
     }
 
-    pub const fn get_vec(&self) -> &Vec<Option<SignatureBytes>> {
+    pub const fn vec(&self) -> &Vec<Option<SignatureBytes>> {
         &self.0
     }
 
@@ -240,7 +240,7 @@ impl ViewNumber {
         Self(0)
     }
 
-    pub const fn get_int(&self) -> u64 {
+    pub const fn int(&self) -> u64 {
         self.0
     }
 }
@@ -268,7 +268,7 @@ impl EpochLength {
         Self(int)
     }
 
-    pub const fn get_int(&self) -> u32 {
+    pub const fn int(&self) -> u32 {
         self.0
     }
 }
@@ -282,7 +282,7 @@ impl BufferSize {
         Self(int)
     }
 
-    pub const fn get_int(&self) -> u64 {
+    pub const fn int(&self) -> u64 {
         self.0
     }
 }

--- a/src/types/basic.rs
+++ b/src/types/basic.rs
@@ -14,8 +14,7 @@
 use std::{
     collections::{hash_map, hash_set, HashMap, HashSet}, 
     fmt::{self, Display, Formatter}, 
-    hash::Hash,
-    ops::{Add, AddAssign}
+    hash::Hash, ops::{Add, AddAssign}
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 
@@ -233,6 +232,10 @@ impl SignatureSet {
 pub struct ViewNumber(u64);
 
 impl ViewNumber {
+    pub fn new(int: u64) -> Self {
+        Self(int)
+    }
+    
     pub const fn init() -> Self {
         Self(0)
     }

--- a/src/types/basic.rs
+++ b/src/types/basic.rs
@@ -14,7 +14,7 @@
 use std::{
     collections::{hash_map, hash_set, HashMap, HashSet}, 
     fmt::{self, Display, Formatter}, 
-    hash::Hash, ops::{Add, AddAssign}
+    hash::Hash, ops::{Add, AddAssign, SubAssign}
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 
@@ -284,6 +284,18 @@ impl BufferSize {
 
     pub const fn get_int(&self) -> u64 {
         self.0
+    }
+}
+
+impl AddAssign<u64> for BufferSize {
+    fn add_assign(&mut self, rhs: u64) {
+        self.0.add_assign(rhs)
+    }
+}
+
+impl SubAssign<u64> for BufferSize {
+    fn sub_assign(&mut self, rhs: u64) {
+        self.0.sub_assign(rhs)
     }
 }
 

--- a/src/types/validators.rs
+++ b/src/types/validators.rs
@@ -131,7 +131,7 @@ impl ValidatorSet {
 
         TotalPower::new(
         (self.total_power()
-            .get_int()
+            .int()
             .checked_mul(2)
             .expect(TOTAL_POWER_OVERFLOW)
             / 3


### PR DESCRIPTION
This PR primary focuses on the `Pacemaker `implementation but also includes the following:
1. Re-naming of the newtype pattern struct methods to comply with Rust's official recommendations,
2. Networking implementation.

It is also intended to include proper documentation, and tentative error handling for all of the above.

The error handling is tentative, since I need to put more thought on how to do it consistently across the entire repository. For instance, currently the `PacemakerError` is of this from:
```rust
#[derive(Debug)]
pub enum PacemakerError {
    UpdateViewError(UpdateViewError),
    ExtendViewError(ExtendViewError),
}
```
but inside the `Pacemaker` methods we often call a method of the `BlockTree`, e.g., `committed_validator_set` or `highest_qc`/`highest_tc`, which can panic. To be consistent, and for the sake of better error handling and testing, the `BlockTree` getters and setters should also return `Result<T, E>`, and the `E` should be propagated to `PacemakerError` for example like this:
```rust
#[derive(Debug)]
pub enum PacemakerError {
    UpdateViewError(UpdateViewError),
    ExtendViewError(ExtendViewError),
    BlockTreeGetError(BlockTreeGetError),
}
```
Yet building an enum error for this requires some more thought. I am also thinking of implementing `std::error::Error`, possibly with [thiserror crate](https://crates.io/crates/thiserror/1.0.24/dependencies) derive macros, but again this needs to be done consistently across the repository, so I am thinking of doing that in one of the later milestones.

Naming and nesting errors itself is tricky, and ideally should be done at the stage of defining the type signature of methods... Having a fresh (potentially wrapping around another error) type for each caller function is an overkill I think, so often the lower level callee error type should also be the error type of the caller. This is what I did for the Pacemaker. Some other way of grouping errors might be based on the associated struct name of the method, e.g., `PacemakerStateError`, `ViewInfoError`.

@lyulka thoughts?