### PR TITLE
Deploy docs workflow

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -6,12 +6,12 @@
 name: Deploy complete Rustdocs
 run-name: Deploy docs for branch/release `${{ github.ref }}` to GitHub Pages.
 
-# List of events that trigger the deploying of Rustdocs.
+# List of event types that trigger the deploying of Rustdocs.
 on:
-    # Receiving a push to any branch.
+    # 1. Receiving a push to any branch.
     push:
 
-    # Releasing a prerelease or stable release.
+    # 2. Releasing a prerelease or stable release.
     release:
         types:
             - prereleased
@@ -49,8 +49,8 @@ jobs:
                 fetch-depth: 0
                 token: ${{ secrets.HOTSTUFF_RS_DOCS_PUSHER }}
 
-            - id: compute_subfolder_path
-              name: Compute path to the subfolder the docs should be in 
+            - name: Compute path to the subfolder the docs should be in 
+              id: compute_subfolder_path
               run: |
                 subfolder_path=$GITHUB_REF_TYPE/$GITHUB_REF_NAME/
                 echo "subfolder_path=$subfolder_path" >> $GITHUB_OUTPUT
@@ -76,16 +76,34 @@ jobs:
                 name: complete_docs
                 path: ${{ steps.compute_subfolder_path.outputs.subfolder_path }}
 
-            - name: Stage and commit the changes to `hotstuff_rs_docs`
+            - name: Stage and commit the changes (if there are any) to `hotstuff_rs_docs`
+              id: commit_changes
               run: |
-                git config --global user.name "github-actions[bot]"
-                git config --global user.email "github-actions[bot]@users.noreply.github.com"
-                git add .
-                git commit -a -m "$COMMIT_MESSAGE"
+                git diff --quiet --exit-code
+
+                # If there are changes to the Rustdocs, then commit these changes.
+                if [ $? = 1 ]; then
+                  echo "docs_changed=true" >> $GITHUB_OUTPUT
+                  git config --global user.name "github-actions[bot]"
+                  git config --global user.email "github-actions[bot]@users.noreply.github.com"
+                  git add .
+                  git commit -a -m "$COMMIT_MESSAGE"
+
+                # If there are no changes to the Rustdocs, skip the next (push) step.
+                elif [ $? = 0 ]; then
+                  echo "docs_changed=false" >> $GITHUB_OUTPUT
+
+                # If something unexpected happened during `git diff`, fail the job and therefore the workflow.
+                else
+                  echo "unhandled error when executing `git diff`"
+                  exit 1
+                fi
+                
               env: 
                 COMMIT_MESSAGE: "add docs for branch/release `${{ github.ref }}`"
 
-            - name: Push the changes to `hotstuff_rs_docs` to the remote
+            - if: ${{ steps.commit_changes.outputs.docs_changed }}
+              name: Push the changes to `hotstuff_rs_docs` to the remote
               uses: ad-m/github-push-action@master
               with:
                 github_token: ${{ secrets.HOTSTUFF_RS_DOCS_PUSHER }}

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -56,9 +56,10 @@ jobs:
                 if [ -d $SUBFOLDER_PATH ]; then
                     echo "Subfolder `$SUB_FOLDER_PATH` already exists, clearing its contents"
                     rm -rf "${SUBFOLDER_PATH:?}/"*
-                else if
+                else
                     echo "Subfolder `$SUBFOLDER_PATH` doesn't exist yet. Creating it"
                     mkdir -p "$SUBFOLDER_PATH"
+                fi
               env:
                 SUBFOLDER_PATH: ${{ steps.compute_subfolder_path.outputs.subfolder_path }}
             

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -17,11 +17,11 @@ jobs:
         name: Build rustdocs
         runs-on: ubuntu-latest
         steps:
-            - name: Install Rust toolchain
-              uses: actions-rust-lang/setup-rust-toolchain@v1 
-
             - name: Checkout updated `hotstuff_rs` ref 
               uses: actions/checkout@v4
+        
+            - name: Install Rust toolchain
+              uses: actions-rust-lang/setup-rust-toolchain@v1 
 
             - name: Generate complete rustdocs 
               run: cargo doc --document-private-items --no-deps 

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -79,7 +79,7 @@ jobs:
             - name: Stage and commit the changes (if there are any) to `hotstuff_rs_docs`
               id: commit_changes
               run: |
-                git diff --quiet --exit-code
+                git diff --exit-code
 
                 # If there are changes to the Rustdocs, then commit these changes.
                 if [ $? = 1 ]; then

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -82,6 +82,6 @@ jobs:
             
             - name: Push the changes to `hotstuff_rs_docs` to the remote
               run: |
-                git push "https://${PAT}@github.com/parallelchain-io/hotstuff_rs_docs.git" HEAD:master
+                git push "https://github-actions[bot]:${PAT}@github.com/parallelchain-io/hotstuff_rs_docs.git" HEAD:master
               env:
                 PAT: "${{ secrets.HOTSTUFF_RS_DOCS_PUSHER }}"

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -7,8 +7,8 @@
 # understandable just by reading the `name` keys of each step in turn. Additional context and 
 # explanation is provided by the comments in the YAML.
 
-name: Deploy complete Rustdocs to GH Pages.
-run-name: Deploy docs for `${{ github.ref }}`.
+name: Deploy complete Rustdocs to GH Pages
+run-name: Deploy docs for `${{ github.ref }}`
 
 # Event types that trigger the deploying of Rustdocs.
 on:

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -82,7 +82,7 @@ jobs:
             
             - name: Push the changes to `hotstuff_rs_docs` to the remote
               run: |
-                git remote set-url origin "https://github-actions[bot]:${PAT}@github.com/parallelchain-io/hotstuff_rs_docs.git"
+                git remote set-url origin "https://${PAT}@github.com/parallelchain-io/hotstuff_rs_docs.git"
                 git push origin HEAD:master
               env:
-                PAT: "${{ secrets.HOTSTUFF_RS_DOCS_PUSHER }}"
+                PAT: ${{ secrets.HOTSTUFF_RS_DOCS_PUSHER }}

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -34,7 +34,7 @@ jobs:
 
     push_docs:
         name: Push rustdocs to `hotstuff_rs_docs` repository
-        runs-on: ubuntu_latest
+        runs-on: ubuntu-latest
         needs: build_docs
         steps:
             - name: Checkout latest `hotstuff_rs_docs`

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -8,104 +8,105 @@ run-name: Deploy docs for branch/release `${{ github.ref }}` to GitHub Pages.
 
 # List of event types that trigger the deploying of Rustdocs.
 on:
-    # 1. Receiving a push to any branch.
-    push:
+  # 1. Receiving a push to any branch.
+  push:
 
-    # 2. Releasing a prerelease or stable release.
-    release:
-        types:
-            - prereleased
-            - released
+  # 2. Releasing a prerelease or stable release.
+  release:
+    types:
+      - prereleased
+      - released
 
 jobs:
-    build_docs:
-        name: Build rustdocs
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout updated `hotstuff_rs` ref 
-              uses: actions/checkout@v4
+  build_docs:
+    name: Build rustdocs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout updated `hotstuff_rs` ref 
+        uses: actions/checkout@v4
+    
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1 
+
+      - name: Generate complete rustdocs 
+        run: cargo doc --document-private-items --no-deps 
+
+      - name: Upload rustdocs as `complete_docs` artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: complete_docs
+          path: target/doc/
+
+  push_docs:
+    name: Push rustdocs to `hotstuff_rs_docs` repository
+    runs-on: ubuntu-latest
+    needs: build_docs
+    steps:
+      - name: Checkout latest `hotstuff_rs_docs`
+        uses: actions/checkout@v4
+        with:
+          repository: parallelchain-io/hotstuff_rs_docs
+          fetch-depth: 0
+          token: ${{ secrets.HOTSTUFF_RS_DOCS_PUSHER }}
+
+      - name: Compute path to the subfolder the docs should be placed in 
+        id: compute_subfolder_path
+        run: |
+          subfolder_path=$GITHUB_REF_TYPE/$GITHUB_REF_NAME/
+          echo "subfolder_path=$subfolder_path" >> $GITHUB_OUTPUT
+        env:
+            GITHUB_REF_TYPE: "${{ github.ref_type }}"
+            GITHUB_REF_NAME: "${{ github.ref_name }}"
+
+      - name: Prepare the subfolder
+        run: |
+          if [ -d $SUBFOLDER_PATH ]; then
+              echo "Subfolder `$SUB_FOLDER_PATH` already exists, clearing its contents"
+              rm -rf "${SUBFOLDER_PATH:?}/"*
+          else
+              echo "Subfolder `$SUBFOLDER_PATH` doesn't exist yet. Creating it"
+              mkdir -p "$SUBFOLDER_PATH"
+          fi
+        env:
+          SUBFOLDER_PATH: ${{ steps.compute_subfolder_path.outputs.subfolder_path }}
+      
+      - name: Download `complete_docs` artifact to the subfolder
+        uses: actions/download-artifact@v4 
+        with:
+          name: complete_docs
+          path: ${{ steps.compute_subfolder_path.outputs.subfolder_path }}
         
-            - name: Install Rust toolchain
-              uses: actions-rust-lang/setup-rust-toolchain@v1 
+      - name: Stage and commit the changes (if there are any) to `hotstuff_rs_docs`
+        id: commit_changes
+        run: |
+          git diff --exit-code
+          git_diff_exit_code=$?
 
-            - name: Generate complete rustdocs 
-              run: cargo doc --document-private-items --no-deps 
+          # If there are changes to the Rustdocs, then commit these changes.
+          if [ $git_diff_exit_code -eq 1 ]; then
+            echo "docs_changed=true" >> $GITHUB_OUTPUT
+            git config --global user.name "github-actions[bot]"
+            git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            git add .
+            git commit -a -m "$COMMIT_MESSAGE"
 
-            - name: Upload rustdocs as `complete_docs` artifact
-              uses: actions/upload-artifact@v4
-              with:
-                name: complete_docs
-                path: target/doc/
+          # If there are no changes to the Rustdocs, skip the next (push) step.
+          elif [ $git_diff_exit_code -eq 0 ]; then
+            echo "The Rustdocs weren't changed, so we should skip the next (push) step."
+            echo "docs_changed=false" >> $GITHUB_OUTPUT
 
-    push_docs:
-        name: Push rustdocs to `hotstuff_rs_docs` repository
-        runs-on: ubuntu-latest
-        needs: build_docs
-        steps:
-            - name: Checkout latest `hotstuff_rs_docs`
-              uses: actions/checkout@v4
-              with:
-                repository: parallelchain-io/hotstuff_rs_docs
-                fetch-depth: 0
-                token: ${{ secrets.HOTSTUFF_RS_DOCS_PUSHER }}
+          # If something unexpected happened during 'git diff', fail the job and therefore the workflow.
+          else
+            echo "unhandled error when executing 'git diff'"
+            exit 1
+          fi
+          
+        env: 
+          COMMIT_MESSAGE: "add docs for branch/release `${{ github.ref }}`"
 
-            - name: Compute path to the subfolder the docs should be in 
-              id: compute_subfolder_path
-              run: |
-                subfolder_path=$GITHUB_REF_TYPE/$GITHUB_REF_NAME/
-                echo "subfolder_path=$subfolder_path" >> $GITHUB_OUTPUT
-              env:
-                  GITHUB_REF_TYPE: "${{ github.ref_type }}"
-                  GITHUB_REF_NAME: "${{ github.ref_name }}"
-
-            - name: Prepare the subfolder
-              run: |
-                if [ -d $SUBFOLDER_PATH ]; then
-                    echo "Subfolder `$SUB_FOLDER_PATH` already exists, clearing its contents"
-                    rm -rf "${SUBFOLDER_PATH:?}/"*
-                else
-                    echo "Subfolder `$SUBFOLDER_PATH` doesn't exist yet. Creating it"
-                    mkdir -p "$SUBFOLDER_PATH"
-                fi
-              env:
-                SUBFOLDER_PATH: ${{ steps.compute_subfolder_path.outputs.subfolder_path }}
-            
-            - name: Download `complete_docs` artifact to the subfolder
-              uses: actions/download-artifact@v4 
-              with:
-                name: complete_docs
-                path: ${{ steps.compute_subfolder_path.outputs.subfolder_path }}
-              
-            - name: Stage and commit the changes (if there are any) to `hotstuff_rs_docs`
-              id: commit_changes
-              run: |
-                git diff --exit-code
-                git_diff_exit_code=$?
-
-                # If there are changes to the Rustdocs, then commit these changes.
-                if [ $git_diff_exit_code -eq 1 ]; then
-                  echo "docs_changed=true" >> $GITHUB_OUTPUT
-                  git config --global user.name "github-actions[bot]"
-                  git config --global user.email "github-actions[bot]@users.noreply.github.com"
-                  git add .
-                  git commit -a -m "$COMMIT_MESSAGE"
-
-                # If there are no changes to the Rustdocs, skip the next (push) step.
-                elif [ $git_diff_exit_code -eq 0 ]; then
-                  echo "docs_changed=false" >> $GITHUB_OUTPUT
-
-                # If something unexpected happened during 'git diff', fail the job and therefore the workflow.
-                else
-                  echo "unhandled error when executing 'git diff'"
-                  exit 1
-                fi
-                
-              env: 
-                COMMIT_MESSAGE: "add docs for branch/release `${{ github.ref }}`"
-
-            - if: ${{ steps.commit_changes.outputs.docs_changed == 'true' }}
-              name: Push the changes to `hotstuff_rs_docs` to the remote
-              uses: ad-m/github-push-action@master
-              with:
-                github_token: ${{ secrets.HOTSTUFF_RS_DOCS_PUSHER }}
-                repository: parallelchain-io/hotstuff_rs_docs
+      - if: ${{ steps.commit_changes.outputs.docs_changed == 'true' }}
+        name: If there were changes to the Rustdocs, push them to the remote
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.HOTSTUFF_RS_DOCS_PUSHER }}
+          repository: parallelchain-io/hotstuff_rs_docs

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -35,6 +35,7 @@ jobs:
     push_docs:
         name: Push rustdocs to `hotstuff_rs_docs` repository
         runs-on: ubuntu_latest
+        needs: build_docs
         steps:
             - name: Checkout latest `hotstuff_rs_docs`
               uses: actions/checkout@v4

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,3 +1,8 @@
+# GitHub Actions Workflow that generates Rustdocs for HotStuff-rs every time a commit is pushed to a branch
+# or a stable release or pre-release is released, and then pushes this Rustdocs to the master branch of the
+# [hotstuff_rs_docs](https://github.com/parallelchain-io/hotstuff_rs_docs) repository so that it may
+# automatically be deployed to GitHub Pages.
+
 name: Deploy complete Rustdocs
 run-name: Deploy docs for branch/release `${{ github.ref }}` to GitHub Pages.
 

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -82,6 +82,6 @@ jobs:
             
             - name: Push the changes to `hotstuff_rs_docs` to the remote
               run: |
-                git push "https://${PAT}@github.com/parallelchain-io/hotstuff_rs_docs.git" HEAD:main
+                git push "https://${PAT}@github.com/parallelchain-io/hotstuff_rs_docs.git" HEAD:master
               env:
                 PAT: "${{ secrets.HOTSTUFF_RS_DOCS_PUSHER }}"

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,12 +1,16 @@
-# GitHub Actions Workflow that generates Rustdocs for HotStuff-rs every time a commit is pushed to a branch
-# or a stable release or pre-release is released, and then pushes this Rustdocs to the master branch of the
-# [hotstuff_rs_docs](https://github.com/parallelchain-io/hotstuff_rs_docs) repository so that it may
-# automatically be deployed to GitHub Pages.
+# GitHub Actions Workflow that generates Rustdocs for HotStuff-rs every time a commit is pushed to a 
+# branch or a stable release or pre-release is released, and then pushes this Rustdocs to the master
+# branch of the [hotstuff_rs_docs](https://github.com/parallelchain-io/hotstuff_rs_docs) repository so
+# that it may automatically be deployed to GitHub Pages.
+#
+# The jobs and steps in this workflow are quite straightforward, and the high-level flow should be
+# understandable just by reading the `name` keys of each step in turn. Additional context and 
+# explanation is provided by the comments in the YAML.
 
 name: Deploy complete Rustdocs
 run-name: Deploy docs for branch/release `${{ github.ref }}` to GitHub Pages.
 
-# List of event types that trigger the deploying of Rustdocs.
+# Event types that trigger the deploying of Rustdocs.
 on:
   # 1. Receiving a push to any branch.
   push:
@@ -17,11 +21,17 @@ on:
       - prereleased
       - released
 
+# Jobs that are triggered by events with the listed types.
 jobs:
+
+  # Check out the latest update to the `hotstuff_rs` repo, run `cargo doc` on it, and upload the
+  # generated docs as an artifact.
   build_docs:
     name: Build rustdocs
     runs-on: ubuntu-latest
     steps:
+      # We must check out before we run setup-rust-toolchain, because setup-rust-toolchain runs `cargo 
+      # metadata`, which looks for a `Cargo.toml` in the working directory.
       - name: Checkout updated `hotstuff_rs` ref 
         uses: actions/checkout@v4
     
@@ -37,6 +47,8 @@ jobs:
           name: complete_docs
           path: target/doc/
 
+  # Download the generated docs artifact, then check whether the docs have changed compared to the
+  # latest `hotstuff_rs_docs` commit. If so, then commit the changes and push it to the remote.
   push_docs:
     name: Push rustdocs to `hotstuff_rs_docs` repository
     runs-on: ubuntu-latest
@@ -49,14 +61,34 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.HOTSTUFF_RS_DOCS_PUSHER }}
 
-      - name: Compute path to the subfolder the docs should be placed in 
+      - name: Compute the path of the subfolder that the docs for this branch/tag should be placed in 
         id: compute_subfolder_path
+        # We first have to sanitize GITHUB_REF_NAME so that it does not contain any characters that will
+        # affect the folder structure of `hotstuff_rs_docs` in unwanted ways.
+        #
+        # To illustrate the necessity of sanitization, consider what could happen if we **do not** sanitize
+        # the refname "dev/v0.4". In this case, the folder structure will contain the following subtree:
+        # - dev/
+        #   - v0.4/
+        #       - Rustdocs for "dev/v0.4"
+        # 
+        # If, in this scenario, someone pushes a commit to a branch called "dev", the "Prepare the subfolder"
+        # step will clear the entirity of "dev/" before placing the Rustdocs for "dev" under it, resulting in
+        # the following, undesired folder structure:
+        # - dev/
+        #    - Rustdocs for "dev/"
+        #    - (The Rustdocs for "dev/v0.4" have been accidentally deleted!)
+        #
+        # The sanitization step below ensures that the folder structure in the scenario becomes the following
+        # instead:
+        # - dev/
+        #     - Rustdocs for "dev/"
+        # - dev/%2Fv0.4
+        #     - Rustdocs for "dev/v0.4"
         run: |
-          subfolder_path=$GITHUB_REF_TYPE/$GITHUB_REF_NAME/
+          sanitized_ref_name=$(python3 -c "import urllib.parse; print(urllib.parse.quote(${GITHUB_REF_NAME}, safe='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.'))")
+          subfolder_path=$GITHUB_REF_TYPE/$sanitized_ref_name/
           echo "subfolder_path=$subfolder_path" >> $GITHUB_OUTPUT
-        env:
-            GITHUB_REF_TYPE: "${{ github.ref_type }}"
-            GITHUB_REF_NAME: "${{ github.ref_name }}"
 
       - name: Prepare the subfolder
         run: |
@@ -90,9 +122,12 @@ jobs:
             git add .
             git commit -a -m "$COMMIT_MESSAGE"
 
-          # If there are no changes to the Rustdocs, skip the next (push) step.
+          # If there are no changes to the Rustdocs, we do not commit, and we skip the next (push) step.
+          #
+          # If we had **instead** committed, then the `git commit` will "fail" with a non-zero exit code,
+          # causing the job to display as "failed" in the GitHub Actions UI.
           elif [ $git_diff_exit_code -eq 0 ]; then
-            echo "The Rustdocs weren't changed, so we should skip the next (push) step."
+            echo "The Rustdocs weren't changed, so we do not commit, and we skip the next (push) step.
             echo "docs_changed=false" >> $GITHUB_OUTPUT
 
           # If something unexpected happened during 'git diff', fail the job and therefore the workflow.

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -81,14 +81,14 @@ jobs:
               run: |
                 git diff --exit-code
                 # If there are changes to the Rustdocs, then commit these changes.
-                if [ $? = 1 ]; then
+                if [ $? -eq 1 ]; then
                   echo "docs_changed=true" >> $GITHUB_OUTPUT
                   git config --global user.name "github-actions[bot]"
                   git config --global user.email "github-actions[bot]@users.noreply.github.com"
                   git add .
                   git commit -a -m "$COMMIT_MESSAGE"
                 # If there are no changes to the Rustdocs, skip the next (push) step.
-                elif [ $? = 0 ]; then
+                elif [ $? -eq 0 ]; then
                   echo "docs_changed=false" >> $GITHUB_OUTPUT
                 # If something unexpected happened during 'git diff', fail the job and therefore the workflow.
                 else

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -93,9 +93,9 @@ jobs:
                 elif [ $? = 0 ]; then
                   echo "docs_changed=false" >> $GITHUB_OUTPUT
 
-                # If something unexpected happened during `git diff`, fail the job and therefore the workflow.
+                # If something unexpected happened during 'git diff', fail the job and therefore the workflow.
                 else
-                  echo "unhandled error when executing `git diff`"
+                  echo "unhandled error when executing 'git diff'"
                   exit 1
                 fi
                 

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,0 +1,85 @@
+name: Deploy complete Rustdocs
+run-name: Deploy docs for branch/release `${{ github.ref }}` to GitHub Pages.
+
+# List of events that trigger the deploying of Rustdocs.
+on:
+    # Receiving a push to any branch.
+    push:
+
+    # Releasing a prerelease or stable release.
+    release:
+        types:
+            - prereleased
+            - released
+
+jobs:
+    build_docs:
+        name: Build rustdocs
+        runs-on: ubuntu_latest
+        steps:
+            - name: Install Rust toolchain
+              uses: actions-rust-lang/setup-rust-toolchain@v1 
+
+            - name: Checkout updated `hotstuff_rs` ref 
+              uses: actions/checkout@v4
+
+            - name: Generate complete rustdocs 
+              uses: cargo doc --document-private-items --no-deps 
+
+            - name: Upload rustdocs as `complete_docs` artifact
+              uses: actions/upload-artifact@v4
+              with:
+                name: complete_docs
+                path: target/doc/
+
+    push_docs:
+        name: Push rustdocs to `hotstuff_rs_docs` repository
+        runs-on: ubuntu_latest
+        steps:
+            - name: Checkout latest `hotstuff_rs_docs`
+              uses: actions/checkout@v4
+              with:
+                repository: parallelchain-io/hotstuff_rs_docs
+
+            - id: compute_subfolder_path
+              name: Compute path to the subfolder the docs should be in 
+              run: |
+                subfolder_path=$GITHUB_REF_TYPE/$GITHUB_REF_NAME/
+                echo "subfolder_path=$subfolder_path" >> $GITHUB_ENV
+              env:
+                  GITHUB_REF_TYPE: "${{ github.ref_type }}"
+                  GITHUB_REF_NAME: "${{ github.ref_name }}"
+
+            - name: Prepare the subfolder
+              run: |
+                if [ -d $SUBFOLDER_PATH ]; then
+                    echo "Subfolder `$SUB_FOLDER_PATH` already exists, clearing its contents"
+                    rm -rf "${SUBFOLDER_PATH:?}/"*
+                else if
+                    echo "Subfolder `$SUBFOLDER_PATH` doesn't exist yet. Creating it"
+                    mkdir -p "$SUBFOLDER_PATH"
+              env:
+                SUBFOLDER_PATH: ${{ steps.compute_subfolder_path.outputs.subfolder_path }}
+            
+            - name: Download `complete_docs` artifact to the subfolder
+              uses: actions/download-artifact@v4 
+              with:
+                name: complete_docs
+                path: ${{ steps.compute_subfolder_path.outputs.subfolder_path }}
+
+            - name: Stage the changes to `hotstuff_rs_docs`
+              run: git add .
+
+            - name: Commit the changes to `hotstuff_rs_docs`
+              run: |
+                git config --global user.name "github-actions[bot]"
+                git config --global user.email "github-actions[bot]@users.noreply.github.com"
+                git commit -m "$COMMIT_MESSAGE"
+              env: 
+                COMMIT_MESSAGE: "add docs for branch/release `${{ github.ref }}`"
+            
+            - name: Push the changes to `hotstuff_rs_docs` to the remote
+              run: |
+                git push "https://${PAT}@github.com/parallelchain-io/hotstuff_rs_docs.git" HEAD:main
+              env:
+                PAT: "${{ secrets.HOTSTUFF_RS_DOCS_PUSHER }}"

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -76,16 +76,11 @@ jobs:
                 name: complete_docs
                 path: ${{ steps.compute_subfolder_path.outputs.subfolder_path }}
               
-            - name: Test multi-line step with an empty line in the middle
-              run: |
-                echo "hello"
-
-                echo "world"
-
             - name: Stage and commit the changes (if there are any) to `hotstuff_rs_docs`
               id: commit_changes
               run: |
                 git diff --exit-code
+                echo $?
 
                 # If there are changes to the Rustdocs, then commit these changes.
                 if [ $? = 1 ]; then

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -82,6 +82,7 @@ jobs:
             
             - name: Push the changes to `hotstuff_rs_docs` to the remote
               run: |
-                git push "https://github-actions[bot]:${PAT}@github.com/parallelchain-io/hotstuff_rs_docs.git" HEAD:master
+                git remote set-url origin "https://github-actions[bot]:${PAT}@github.com/parallelchain-io/hotstuff_rs_docs.git"
+                git push origin HEAD:master
               env:
                 PAT: "${{ secrets.HOTSTUFF_RS_DOCS_PUSHER }}"

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -7,8 +7,8 @@
 # understandable just by reading the `name` keys of each step in turn. Additional context and 
 # explanation is provided by the comments in the YAML.
 
-name: Deploy complete Rustdocs
-run-name: Deploy docs for `${{ github.ref }}` to GH Pages.
+name: Deploy complete Rustdocs to GH Pages.
+run-name: Deploy docs for `${{ github.ref }}`.
 
 # Event types that trigger the deploying of Rustdocs.
 on:

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -80,16 +80,20 @@ jobs:
               id: commit_changes
               run: |
                 git diff --exit-code
+                git_diff_exit_code=$?
+
                 # If there are changes to the Rustdocs, then commit these changes.
-                if [ $? -eq 1 ]; then
+                if [ $git_diff_exit_code -eq 1 ]; then
                   echo "docs_changed=true" >> $GITHUB_OUTPUT
                   git config --global user.name "github-actions[bot]"
                   git config --global user.email "github-actions[bot]@users.noreply.github.com"
                   git add .
                   git commit -a -m "$COMMIT_MESSAGE"
+
                 # If there are no changes to the Rustdocs, skip the next (push) step.
-                elif [ $? -eq 0 ]; then
+                elif [ $git_diff_exit_code -eq 0 ]; then
                   echo "docs_changed=false" >> $GITHUB_OUTPUT
+
                 # If something unexpected happened during 'git diff', fail the job and therefore the workflow.
                 else
                   echo "unhandled error when executing 'git diff'"

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -127,7 +127,7 @@ jobs:
           # If we had **instead** committed, then the `git commit` will "fail" with a non-zero exit code,
           # causing the job to display as "failed" in the GitHub Actions UI.
           elif [ $git_diff_exit_code -eq 0 ]; then
-            echo "The Rustdocs weren't changed, so we do not commit, and we skip the next (push) step.
+            echo "The Rustdocs weren't changed, so we do not commit, and we skip the next (push) step."
             echo "docs_changed=false" >> $GITHUB_OUTPUT
 
           # If something unexpected happened during 'git diff', fail the job and therefore the workflow.

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -46,7 +46,7 @@ jobs:
               name: Compute path to the subfolder the docs should be in 
               run: |
                 subfolder_path=$GITHUB_REF_TYPE/$GITHUB_REF_NAME/
-                echo "subfolder_path=$subfolder_path" >> $GITHUB_ENV
+                echo "subfolder_path=$subfolder_path" >> $GITHUB_OUTPUT
               env:
                   GITHUB_REF_TYPE: "${{ github.ref_type }}"
                   GITHUB_REF_NAME: "${{ github.ref_name }}"

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -69,20 +69,16 @@ jobs:
                 name: complete_docs
                 path: ${{ steps.compute_subfolder_path.outputs.subfolder_path }}
 
-            - name: Stage the changes to `hotstuff_rs_docs`
-              run: git add .
-
-            - name: Commit the changes to `hotstuff_rs_docs`
+            - name: Stage and commit the changes to `hotstuff_rs_docs`
               run: |
                 git config --global user.name "github-actions[bot]"
                 git config --global user.email "github-actions[bot]@users.noreply.github.com"
-                git commit -m "$COMMIT_MESSAGE"
+                git commit -a -m "$COMMIT_MESSAGE"
               env: 
                 COMMIT_MESSAGE: "add docs for branch/release `${{ github.ref }}`"
-            
+
             - name: Push the changes to `hotstuff_rs_docs` to the remote
-              run: |
-                git remote set-url origin "https://${PAT}@github.com/parallelchain-io/hotstuff_rs_docs.git"
-                git push origin HEAD:master
-              env:
-                PAT: ${{ secrets.HOTSTUFF_RS_DOCS_PUSHER }}
+              uses: ad-m/github-push-action@master
+              with:
+                github_token: ${{ secrets.HOTSTUFF_RS_DOCS_PUSHER }}
+                repository: parallelchain-io/hotstuff_rs_docs

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -15,7 +15,7 @@ on:
 jobs:
     build_docs:
         name: Build rustdocs
-        runs-on: ubuntu_latest
+        runs-on: ubuntu-latest
         steps:
             - name: Install Rust toolchain
               uses: actions-rust-lang/setup-rust-toolchain@v1 

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -8,7 +8,7 @@
 # explanation is provided by the comments in the YAML.
 
 name: Deploy complete Rustdocs
-run-name: Deploy docs for branch/release `${{ github.ref }}` to GitHub Pages.
+run-name: Deploy docs for `${{ github.ref }}` to GH Pages.
 
 # Event types that trigger the deploying of Rustdocs.
 on:
@@ -86,7 +86,7 @@ jobs:
         # - dev/%2Fv0.4
         #     - Rustdocs for "dev/v0.4"
         run: |
-          sanitized_ref_name=$(python3 -c "import urllib.parse; print(urllib.parse.quote(${GITHUB_REF_NAME}, safe='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.'))")
+          sanitized_ref_name=$(python3 -c "import urllib.parse; print(urllib.parse.quote('${GITHUB_REF_NAME}', safe='abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.'))")
           subfolder_path=$GITHUB_REF_TYPE/$sanitized_ref_name/
           echo "subfolder_path=$subfolder_path" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -24,7 +24,7 @@ jobs:
               uses: actions/checkout@v4
 
             - name: Generate complete rustdocs 
-              uses: cargo doc --document-private-items --no-deps 
+              run: cargo doc --document-private-items --no-deps 
 
             - name: Upload rustdocs as `complete_docs` artifact
               uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -73,6 +73,7 @@ jobs:
               run: |
                 git config --global user.name "github-actions[bot]"
                 git config --global user.email "github-actions[bot]@users.noreply.github.com"
+                git add .
                 git commit -a -m "$COMMIT_MESSAGE"
               env: 
                 COMMIT_MESSAGE: "add docs for branch/release `${{ github.ref }}`"

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -80,7 +80,6 @@ jobs:
               id: commit_changes
               run: |
                 git diff --exit-code
-                echo $?
 
                 # If there are changes to the Rustdocs, then commit these changes.
                 if [ $? = 1 ]; then
@@ -89,11 +88,9 @@ jobs:
                   git config --global user.email "github-actions[bot]@users.noreply.github.com"
                   git add .
                   git commit -a -m "$COMMIT_MESSAGE"
-
                 # If there are no changes to the Rustdocs, skip the next (push) step.
                 elif [ $? = 0 ]; then
                   echo "docs_changed=false" >> $GITHUB_OUTPUT
-
                 # If something unexpected happened during 'git diff', fail the job and therefore the workflow.
                 else
                   echo "unhandled error when executing 'git diff'"

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -75,6 +75,12 @@ jobs:
               with:
                 name: complete_docs
                 path: ${{ steps.compute_subfolder_path.outputs.subfolder_path }}
+              
+            - name: Test multi-line step with an empty line in the middle
+              run: |
+                echo "hello"
+
+                echo "world"
 
             - name: Stage and commit the changes (if there are any) to `hotstuff_rs_docs`
               id: commit_changes

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -80,7 +80,6 @@ jobs:
               id: commit_changes
               run: |
                 git diff --exit-code
-
                 # If there are changes to the Rustdocs, then commit these changes.
                 if [ $? = 1 ]; then
                   echo "docs_changed=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -103,7 +103,7 @@ jobs:
               env: 
                 COMMIT_MESSAGE: "add docs for branch/release `${{ github.ref }}`"
 
-            - if: ${{ steps.commit_changes.outputs.docs_changed }}
+            - if: ${{ steps.commit_changes.outputs.docs_changed == 'true' }}
               name: Push the changes to `hotstuff_rs_docs` to the remote
               uses: ad-m/github-push-action@master
               with:

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -41,6 +41,8 @@ jobs:
               uses: actions/checkout@v4
               with:
                 repository: parallelchain-io/hotstuff_rs_docs
+                fetch-depth: 0
+                token: ${{ secrets.HOTSTUFF_RS_DOCS_PUSHER }}
 
             - id: compute_subfolder_path
               name: Compute path to the subfolder the docs should be in 


### PR DESCRIPTION
This PR adds a GitHub workflow that automatically generates Rustdocs for HotStuff-rs and deploys it to GitHub Pages by committing the Rustdocs to the [hotstuff_rs_docs repository](https://github.com/parallelchain-io/hotstuff_rs_docs).